### PR TITLE
upgraded to Bitmovin 2.10.2 and Exoplayer 2.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ And this line to your main project `build.gradle`
 
 ```
 dependencies {
-    compile 'com.bitmovin.analytics:collector:1.3.2'
+    compile 'com.bitmovin.analytics:collector:1.3.3'
 }
 ```
 

--- a/analyticsexample/build.gradle
+++ b/analyticsexample/build.gradle
@@ -38,6 +38,6 @@ dependencies {
     compile project(path: ':collector')
 
     // Pull from Maven Repo
-    // compile 'com.bitmovin.analytics:collector:1.3.2'
+    // compile 'com.bitmovin.analytics:collector:1.3.3'
 
 }

--- a/analyticsexample/src/main/java/com/bitmovin/exoplayeranalyticsexample/MainActivity.java
+++ b/analyticsexample/src/main/java/com/bitmovin/exoplayeranalyticsexample/MainActivity.java
@@ -1,15 +1,15 @@
 package com.bitmovin.exoplayeranalyticsexample;
 
 import android.net.Uri;
+import android.os.Bundle;
 import android.os.Handler;
 import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 
 import com.bitmovin.analytics.analytics.BitmovinAnalytics;
-import com.bitmovin.analytics.enums.CDNProvider;
 import com.bitmovin.analytics.analytics.BitmovinAnalyticsConfig;
+import com.bitmovin.analytics.enums.CDNProvider;
 import com.google.android.exoplayer2.DefaultLoadControl;
 import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.ExoPlayerFactory;
@@ -28,8 +28,6 @@ import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
 import com.google.android.exoplayer2.util.Util;
-
-import java.util.Random;
 
 public class MainActivity extends AppCompatActivity implements View.OnClickListener {
     private SimpleExoPlayer player;
@@ -56,8 +54,8 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         automationHandler = new Handler();
 
-        automationHandler.postDelayed(new Runnable(){
-            public void run(){
+        automationHandler.postDelayed(new Runnable() {
+            public void run() {
                 releasePlayer();
                 createPlayer();
                 automationHandler.postDelayed(this, automationDelay);
@@ -67,7 +65,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     }
 
     private void createPlayer() {
-        if(player==null) {
+        if (player == null) {
             TrackSelection.Factory videoTrackSelectionFactory
                     = new AdaptiveTrackSelection.Factory(bandwidthMeter);
             RenderersFactory renderersFactory = new DefaultRenderersFactory(this);
@@ -101,24 +99,19 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             //Step 5: Create, prepeare, and play media source
             playerView.setPlayer(player);
 
-            Random r = new Random();
-            int randomInt = r.nextInt(100) + 1;
-
             Uri dashStatic = Uri.parse("http://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd");
-            if(randomInt >= 100) {
-                dashStatic = Uri.parse("http://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-88adfadfa99-f0f6155f6efa.mpd");
-            }
+
             //DASH example
             DashChunkSource.Factory source = new DefaultDashChunkSource.Factory(dataSourceFactory);
-            DashMediaSource dashMediaSource = new DashMediaSource.Factory(source,dataSourceFactory).createMediaSource(dashStatic);
+            DashMediaSource dashMediaSource = new DashMediaSource.Factory(source, dataSourceFactory).createMediaSource(dashStatic);
             player.prepare(dashMediaSource);
             player.setPlayWhenReady(true);
 
         }
     }
 
-    private void releasePlayer(){
-        if(player != null){
+    private void releasePlayer() {
+        if (player != null) {
             player.release();
             bitmovinAnalytics.detachPlayer();
             player = null;
@@ -132,9 +125,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     @Override
     public void onClick(View v) {
-        if (v == releaseButton){
+        if (v == releaseButton) {
             releasePlayer();
-        }else if (v == createButton){
+        } else if (v == createButton) {
             createPlayer();
         }
     }

--- a/bitmovinanalyticsexample/build.gradle
+++ b/bitmovinanalyticsexample/build.gradle
@@ -39,6 +39,6 @@ dependencies {
 
     compile project(path: ':collector')
 
-    //compile 'com.bitmovin.analytics:collector:1.3.2'
+    //compile 'com.bitmovin.analytics:collector:1.3.3'
 
 }

--- a/bitmovinanalyticsexample/src/main/java/com/bitmovin/bitmovinanalyticsexample/MainActivity.java
+++ b/bitmovinanalyticsexample/src/main/java/com/bitmovin/bitmovinanalyticsexample/MainActivity.java
@@ -20,8 +20,6 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private BitmovinAnalytics bitmovinAnalytics;
     private Button releaseButton;
     private Button createButton;
-    private Handler automationHandler;
-    private int automationDelay = 90000;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -40,15 +38,6 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         this.initializePlayer();
 
-//        automationHandler = new Handler();
-//
-//        automationHandler.postDelayed(new Runnable(){
-//            public void run(){
-//                releasePlayer();
-//                initializePlayer();
-//                automationHandler.postDelayed(this, automationDelay);
-//            }
-//        }, automationDelay);
     }
 
     protected void initializeAnalytics(){

--- a/collector/build.gradle
+++ b/collector/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.jfrog.artifactory'
 apply plugin: 'maven-publish'
 
 def packageName = 'com.bitmovin.analytics'
-def libraryVersion = '1.3.2'
+def libraryVersion = '1.3.3'
 
 android {
 
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 27
-        versionCode 6
-        versionName "1.3.2"
+        versionCode 7
+        versionName "1.3.3"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -37,7 +37,7 @@ dependencies {
 
     compile 'com.squareup.okhttp3:okhttp:3.9.1'
     compile 'com.google.code.gson:gson:2.8.2'
-    compile 'com.bitmovin.player:playercore:2.10.0'
+    compile 'com.bitmovin.player:playercore:2.10.2'
 
 }
 

--- a/collector/src/main/java/com/bitmovin/analytics/adapters/BitmovinSdkAdapter.java
+++ b/collector/src/main/java/com/bitmovin/analytics/adapters/BitmovinSdkAdapter.java
@@ -20,6 +20,7 @@ import com.bitmovin.player.api.event.data.SeekedEvent;
 import com.bitmovin.player.api.event.data.SourceLoadedEvent;
 import com.bitmovin.player.api.event.data.StallEndedEvent;
 import com.bitmovin.player.api.event.data.StallStartedEvent;
+import com.bitmovin.player.api.event.data.VideoPlaybackQualityChangedEvent;
 import com.bitmovin.player.api.event.data.VideoQualityChangedEvent;
 import com.bitmovin.player.api.event.listener.OnErrorListener;
 import com.bitmovin.player.api.event.listener.OnPausedListener;
@@ -31,6 +32,7 @@ import com.bitmovin.player.api.event.listener.OnSeekedListener;
 import com.bitmovin.player.api.event.listener.OnSourceLoadedListener;
 import com.bitmovin.player.api.event.listener.OnStallEndedListener;
 import com.bitmovin.player.api.event.listener.OnStallStartedListener;
+import com.bitmovin.player.api.event.listener.OnVideoPlaybackQualityChangedListener;
 import com.bitmovin.player.api.event.listener.OnVideoQualityChangedListener;
 import com.bitmovin.player.config.quality.VideoQuality;
 
@@ -66,7 +68,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         this.bitmovinPlayer.addEventListener(onStallStartedListener);
         this.bitmovinPlayer.addEventListener(onPlaybackFinishedListener);
         this.bitmovinPlayer.addEventListener(onReadyListener);
-        this.bitmovinPlayer.addEventListener(onVideoQualityChangedListener);
+        this.bitmovinPlayer.addEventListener(onVideoPlaybackQualityChangedListener);
         this.bitmovinPlayer.addEventListener(onErrorListener);
     }
 
@@ -81,7 +83,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         this.bitmovinPlayer.removeEventListener(onSeekListener);
         this.bitmovinPlayer.removeEventListener(onPlaybackFinishedListener);
         this.bitmovinPlayer.removeEventListener(onReadyListener);
-        this.bitmovinPlayer.removeEventListener(onVideoQualityChangedListener);
+        this.bitmovinPlayer.removeEventListener(onVideoPlaybackQualityChangedListener);
         this.bitmovinPlayer.removeEventListener(onErrorListener);
     }
 
@@ -219,9 +221,10 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         }
     };
 
-    private OnVideoQualityChangedListener onVideoQualityChangedListener = new OnVideoQualityChangedListener() {
+    private OnVideoPlaybackQualityChangedListener onVideoPlaybackQualityChangedListener = new OnVideoPlaybackQualityChangedListener() {
         @Override
-        public void onVideoQualityChanged(VideoQualityChangedEvent videoQualityChangedEvent) {
+        public void onVideoPlaybackQualityChanged(VideoPlaybackQualityChangedEvent videoPlaybackQualityChangedEvent) {
+            Log.d(TAG, "On Video Quality Changed");
             if ((stateMachine.getCurrentState() == PlayerState.PLAYING) || (stateMachine.getCurrentState() == PlayerState.PAUSE)) {
                 PlayerState originalState = stateMachine.getCurrentState();
                 stateMachine.transitionState(PlayerState.QUALITYCHANGE, getPosition());

--- a/collector/src/main/java/com/bitmovin/analytics/adapters/ExoPlayerAdapter.java
+++ b/collector/src/main/java/com/bitmovin/analytics/adapters/ExoPlayerAdapter.java
@@ -1,5 +1,7 @@
 package com.bitmovin.analytics.adapters;
 
+import android.net.NetworkInfo;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import android.view.Surface;
 
@@ -18,8 +20,10 @@ import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.Timeline;
-import com.google.android.exoplayer2.audio.AudioRendererEventListener;
+import com.google.android.exoplayer2.analytics.AnalyticsListener;
 import com.google.android.exoplayer2.decoder.DecoderCounters;
+import com.google.android.exoplayer2.metadata.Metadata;
+import com.google.android.exoplayer2.source.MediaSourceEventListener;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.source.dash.manifest.DashManifest;
 import com.google.android.exoplayer2.source.hls.HlsManifest;
@@ -28,7 +32,6 @@ import com.google.android.exoplayer2.source.hls.playlist.HlsMediaPlaylist;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.upstream.HttpDataSource;
-import com.google.android.exoplayer2.video.VideoRendererEventListener;
 
 import java.io.IOException;
 
@@ -38,7 +41,7 @@ import static com.google.android.exoplayer2.C.TRACK_TYPE_VIDEO;
 import static com.google.android.exoplayer2.ExoPlaybackException.TYPE_RENDERER;
 import static com.google.android.exoplayer2.ExoPlaybackException.TYPE_SOURCE;
 
-public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, VideoRendererEventListener, AudioRendererEventListener {
+public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, AnalyticsListener {
     private static final String TAG = "ExoPlayerAdapter";
     private final BitmovinAnalyticsConfig config;
     private ExoPlayer exoplayer;
@@ -50,14 +53,13 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, Vi
         this.exoplayer.addListener(this);
         this.config = config;
 
-        attachDebugListeners();
+        attachAnalyticsListener();
     }
 
-    private void attachDebugListeners() {
+    private void attachAnalyticsListener() {
         if (this.exoplayer instanceof SimpleExoPlayer) {
             SimpleExoPlayer simpleExoPlayer = (SimpleExoPlayer) this.exoplayer;
-            simpleExoPlayer.addVideoDebugListener(this);
-            simpleExoPlayer.addAudioDebugListener(this);
+            simpleExoPlayer.addAnalyticsListener(this);
         }
     }
 
@@ -67,8 +69,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, Vi
         }
         if (this.exoplayer instanceof SimpleExoPlayer) {
             SimpleExoPlayer simpleExoPlayer = (SimpleExoPlayer) this.exoplayer;
-            simpleExoPlayer.addVideoDebugListener(this);
-            simpleExoPlayer.addAudioDebugListener(this);
+            simpleExoPlayer.removeAnalyticsListener(this);
         }
     }
 
@@ -82,7 +83,11 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, Vi
             Timeline.Period firstPeriodInWindow = new Timeline.Period();
             if (firstPeriodInWindowIndex >= 0 && firstPeriodInWindowIndex < timeline.getPeriodCount()) {
                 timeline.getPeriod(firstPeriodInWindowIndex, firstPeriodInWindow);
-                return (exoplayer.getCurrentPosition() - firstPeriodInWindow.getPositionInWindowMs()) / 1000;
+                long position = (exoplayer.getCurrentPosition() - firstPeriodInWindow.getPositionInWindowMs());
+                if (position < 0) {
+                    position = 0;
+                }
+                return position;
             }
         }
         return 0;
@@ -272,20 +277,140 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, Vi
         }
     }
 
+
     @Override
-    public void onVideoEnabled(DecoderCounters counters) {
+    public void onPlayerStateChanged(EventTime eventTime, boolean playWhenReady, int playbackState) {
 
     }
 
     @Override
-    public void onVideoDecoderInitialized(String decoderName, long initializedTimestampMs, long initializationDurationMs) {
+    public void onTimelineChanged(EventTime eventTime, int reason) {
 
     }
 
     @Override
-    public void onVideoInputFormatChanged(Format format) {
-        Log.d(TAG, String.format("OnVideoInputFormatChanged: Bitrate: %d Resolution: %d x %d", format.bitrate, format.width, format.height));
+    public void onPositionDiscontinuity(EventTime eventTime, int reason) {
+
+    }
+
+    @Override
+    public void onSeekStarted(EventTime eventTime) {
+
+    }
+
+    @Override
+    public void onSeekProcessed(EventTime eventTime) {
+
+    }
+
+    @Override
+    public void onPlaybackParametersChanged(EventTime eventTime, PlaybackParameters playbackParameters) {
+
+    }
+
+    @Override
+    public void onRepeatModeChanged(EventTime eventTime, int repeatMode) {
+
+    }
+
+    @Override
+    public void onShuffleModeChanged(EventTime eventTime, boolean shuffleModeEnabled) {
+
+    }
+
+    @Override
+    public void onLoadingChanged(EventTime eventTime, boolean isLoading) {
+
+    }
+
+    @Override
+    public void onPlayerError(EventTime eventTime, ExoPlaybackException error) {
+
+    }
+
+    @Override
+    public void onTracksChanged(EventTime eventTime, TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
+
+    }
+
+    @Override
+    public void onLoadStarted(EventTime eventTime, MediaSourceEventListener.LoadEventInfo loadEventInfo, MediaSourceEventListener.MediaLoadData mediaLoadData) {
+
+    }
+
+    @Override
+    public void onLoadCompleted(EventTime eventTime, MediaSourceEventListener.LoadEventInfo loadEventInfo, MediaSourceEventListener.MediaLoadData mediaLoadData) {
+
+    }
+
+    @Override
+    public void onLoadCanceled(EventTime eventTime, MediaSourceEventListener.LoadEventInfo loadEventInfo, MediaSourceEventListener.MediaLoadData mediaLoadData) {
+
+    }
+
+    @Override
+    public void onLoadError(EventTime eventTime, MediaSourceEventListener.LoadEventInfo loadEventInfo, MediaSourceEventListener.MediaLoadData mediaLoadData, IOException error, boolean wasCanceled) {
+
+    }
+
+    @Override
+    public void onDownstreamFormatChanged(EventTime eventTime, MediaSourceEventListener.MediaLoadData mediaLoadData) {
+    }
+
+    @Override
+    public void onUpstreamDiscarded(EventTime eventTime, MediaSourceEventListener.MediaLoadData mediaLoadData) {
+
+    }
+
+    @Override
+    public void onMediaPeriodCreated(EventTime eventTime) {
+
+    }
+
+    @Override
+    public void onMediaPeriodReleased(EventTime eventTime) {
+
+    }
+
+    @Override
+    public void onReadingStarted(EventTime eventTime) {
+
+    }
+
+    @Override
+    public void onBandwidthEstimate(EventTime eventTime, int totalLoadTimeMs, long totalBytesLoaded, long bitrateEstimate) {
+
+    }
+
+    @Override
+    public void onViewportSizeChange(EventTime eventTime, int width, int height) {
+
+    }
+
+    @Override
+    public void onNetworkTypeChanged(EventTime eventTime, @Nullable NetworkInfo networkInfo) {
+
+    }
+
+    @Override
+    public void onMetadata(EventTime eventTime, Metadata metadata) {
+
+    }
+
+    @Override
+    public void onDecoderEnabled(EventTime eventTime, int trackType, DecoderCounters decoderCounters) {
+
+    }
+
+    @Override
+    public void onDecoderInitialized(EventTime eventTime, int trackType, String decoderName, long initializationDurationMs) {
+
+    }
+
+    @Override
+    public void onDecoderInputFormatChanged(EventTime eventTime, int trackType, Format format) {
         if ((this.stateMachine.getCurrentState() == PlayerState.PLAYING) || (this.stateMachine.getCurrentState() == PlayerState.PAUSE)) {
+            Log.d(TAG, String.format("onDecoderInputFormatChanged: Bitrate: %d Resolution: %d x %d", format.bitrate, format.width, format.height));
             long videoTime = getPosition();
             PlayerState originalState = this.stateMachine.getCurrentState();
             this.stateMachine.transitionState(PlayerState.QUALITYCHANGE, videoTime);
@@ -294,53 +419,52 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, Vi
     }
 
     @Override
-    public void onDroppedFrames(int count, long elapsedMs) {
-        Log.d(TAG, String.format("OnDroppedFrames: %d over %d", count, elapsedMs));
+    public void onDecoderDisabled(EventTime eventTime, int trackType, DecoderCounters decoderCounters) {
 
     }
 
     @Override
-    public void onVideoSizeChanged(int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio) {
-        Log.d(TAG, String.format("On Video Sized Changed: %d x %d", width, height));
-    }
-
-    @Override
-    public void onRenderedFirstFrame(Surface surface) {
+    public void onAudioSessionId(EventTime eventTime, int audioSessionId) {
 
     }
 
     @Override
-    public void onVideoDisabled(DecoderCounters counters) {
+    public void onAudioUnderrun(EventTime eventTime, int bufferSize, long bufferSizeMs, long elapsedSinceLastFeedMs) {
 
     }
 
     @Override
-    public void onAudioEnabled(DecoderCounters counters) {
+    public void onDroppedVideoFrames(EventTime eventTime, int droppedFrames, long elapsedMs) {
+        Log.d(TAG, String.format("OnDroppedFrames: %d over %d", droppedFrames, elapsedMs));
+    }
+
+    @Override
+    public void onVideoSizeChanged(EventTime eventTime, int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio) {
+        Log.d(TAG, String.format("On Video Sized Changed: %d x %d Rotation Degrees: %d, PixelRation: %f", width, height, unappliedRotationDegrees, pixelWidthHeightRatio));
+    }
+
+    @Override
+    public void onRenderedFirstFrame(EventTime eventTime, Surface surface) {
 
     }
 
     @Override
-    public void onAudioSessionId(int audioSessionId) {
+    public void onDrmKeysLoaded(EventTime eventTime) {
 
     }
 
     @Override
-    public void onAudioDecoderInitialized(String decoderName, long initializedTimestampMs, long initializationDurationMs) {
+    public void onDrmSessionManagerError(EventTime eventTime, Exception error) {
 
     }
 
     @Override
-    public void onAudioInputFormatChanged(Format format) {
-        Log.d(TAG, String.format("OnAudioInputFormatChnaged: Bitrate: %d MimeType: %s", format.sampleRate, format.sampleMimeType));
-    }
-
-    @Override
-    public void onAudioSinkUnderrun(int bufferSize, long bufferSizeMs, long elapsedSinceLastFeedMs) {
+    public void onDrmKeysRestored(EventTime eventTime) {
 
     }
 
     @Override
-    public void onAudioDisabled(DecoderCounters counters) {
+    public void onDrmKeysRemoved(EventTime eventTime) {
 
     }
 }

--- a/collector/src/main/java/com/bitmovin/analytics/analytics/BitmovinAnalytics.java
+++ b/collector/src/main/java/com/bitmovin/analytics/analytics/BitmovinAnalytics.java
@@ -100,7 +100,7 @@ public class BitmovinAnalytics implements StateMachineListener, LicenseCallback 
 
         //Setting a startup time of 1 to workaround dashboard issue
         data.setPlayerStartupTime(1);
-        data.setStartupTime(duration+1);
+        data.setStartupTime(duration + 1);
 
         data.setVideoTimeStart(playerStateMachine.getVideoTimeStart());
         data.setVideoTimeEnd(playerStateMachine.getVideoTimeEnd());
@@ -234,7 +234,7 @@ public class BitmovinAnalytics implements StateMachineListener, LicenseCallback 
 
     @Override
     public void authenticationCompleted(boolean success) {
-        if(!success){
+        if (!success) {
             detachPlayer();
         }
     }


### PR DESCRIPTION
- Upgraded to Bitmovin 2.10.2 and Exoplayer 2.8.1
  - Two event listeners I was using are now deprecated. Switched to using `AnalyticsListener`
- Fixed bug in Exoplayer adapter where positions were in seconds instead of milliseconds. When fixing this bug, it caused initial positions to be small negative numbers (-25ms for example). Put in a check to set position to zero if it is negative