### PR TITLE
Hotfix/licensing npe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
+### Fixed
+
+- Fixed a possible NullPointerException if the licensing backend responded with a malformed message that didn't contain a message
+
 ## v1.6.2
 
 ### Fixed

--- a/collector/src/main/java/com/bitmovin/analytics/utils/HttpClient.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/HttpClient.java
@@ -47,13 +47,16 @@ public class HttpClient {
 
             @Override
             public void onResponse(Call call, Response response) throws IOException {
-                if (response != null) {
-                    Log.i(TAG, String.format("Analytics HTTP response: %d", response.code()));
+                try {
+                    if (response != null) {
+                        Log.i(TAG, String.format("Analytics HTTP response: %d", response.code()));
+                    }
+                    if (callback != null) {
+                        callback.onResponse(call, response);
+                    }
+                } finally {
+                    response.close();
                 }
-                if (callback != null) {
-                    callback.onResponse(call, response);
-                }
-                response.close();
             }
         });
     }

--- a/collector/src/main/java/com/bitmovin/analytics/utils/HttpClient.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/HttpClient.java
@@ -47,16 +47,13 @@ public class HttpClient {
 
             @Override
             public void onResponse(Call call, Response response) throws IOException {
-                try {
-                    if (response != null) {
-                        Log.i(TAG, String.format("Analytics HTTP response: %d", response.code()));
-                    }
-                    if (callback != null) {
-                        callback.onResponse(call, response);
-                    }
-                } finally {
-                    response.close();
+                if (response != null) {
+                    Log.i(TAG, String.format("Analytics HTTP response: %d", response.code()));
                 }
+                if (callback != null) {
+                    callback.onResponse(call, response);
+                }
+                response.close();
             }
         });
     }

--- a/collector/src/main/java/com/bitmovin/analytics/utils/HttpClient.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/HttpClient.java
@@ -47,11 +47,11 @@ public class HttpClient {
 
             @Override
             public void onResponse(Call call, Response response) throws IOException {
-                if (response != null) {
-                    Log.i(TAG, String.format("Analytics HTTP response: %d", response.code()));
-                }
                 if (callback != null) {
                     callback.onResponse(call, response);
+                }
+                if (response == null) {
+                    return;
                 }
                 response.close();
             }

--- a/collector/src/main/java/com/bitmovin/analytics/utils/LicenseCall.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/LicenseCall.java
@@ -37,19 +37,20 @@ public class LicenseCall {
 
             @Override
             public void onResponse(Call call, Response response) throws IOException {
-                if (response != null) {
-                    LicenseResponse licenseResponse = DataSerializer.deserialize(response.body().string(), LicenseResponse.class);
-                    if (licenseResponse != null && licenseResponse.getStatus().equals("granted")) {
-                        Log.d(TAG, "License response was granted");
-                        callback.authenticationCompleted(true);
-                        return;
-                    }
-                    Log.d(TAG, String.format("License response was denied: %s", licenseResponse.getMessage()));
-                }
-                else {
+                if (response == null) {
                     Log.d(TAG, "License call was denied without providing a response body");
+                    callback.authenticationCompleted(false);
+                    return;
                 }
-                callback.authenticationCompleted(false);
+
+                LicenseResponse licenseResponse = DataSerializer.deserialize(response.body().string(), LicenseResponse.class);
+                if (licenseResponse != null && licenseResponse.getStatus().equals("granted")) {
+                    Log.d(TAG, "License response was granted");
+                    callback.authenticationCompleted(true);
+                    return;
+                }
+                Log.d(TAG, String.format("License response was denied: %s", licenseResponse.getMessage()));
+
             }
         });
 

--- a/collector/src/main/java/com/bitmovin/analytics/utils/LicenseCall.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/LicenseCall.java
@@ -50,6 +50,12 @@ public class LicenseCall {
                     return;
                 }
 
+                if (licenseResponse.getStatus() == null) {
+                    Log.d(TAG, String.format("License response was denied without status"));
+                    callback.authenticationCompleted(false);
+                    return;
+                }
+
                 if (!licenseResponse.getStatus().equals("granted")) {
                     Log.d(TAG, String.format("License response was denied: %s", licenseResponse.getMessage()));
                     callback.authenticationCompleted(false);

--- a/collector/src/main/java/com/bitmovin/analytics/utils/LicenseCall.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/LicenseCall.java
@@ -37,20 +37,26 @@ public class LicenseCall {
 
             @Override
             public void onResponse(Call call, Response response) throws IOException {
-                if (response == null) {
+                if (response == null || response.body() == null) {
                     Log.d(TAG, "License call was denied without providing a response body");
                     callback.authenticationCompleted(false);
                     return;
                 }
 
                 LicenseResponse licenseResponse = DataSerializer.deserialize(response.body().string(), LicenseResponse.class);
-                if (licenseResponse != null && licenseResponse.getStatus().equals("granted")) {
-                    Log.d(TAG, "License response was granted");
-                    callback.authenticationCompleted(true);
+                if (licenseResponse == null) {
+                    Log.d(TAG, "License call was denied without providing a response body");
+                    callback.authenticationCompleted(false);
                     return;
                 }
-                Log.d(TAG, String.format("License response was denied: %s", licenseResponse.getMessage()));
 
+                if (!licenseResponse.getStatus().equals("granted")) {
+                    Log.d(TAG, String.format("License response was denied: %s", licenseResponse.getMessage()));
+                    callback.authenticationCompleted(false);
+                    return;
+                }
+                Log.d(TAG, "License response was granted");
+                callback.authenticationCompleted(true);
             }
         });
 

--- a/collector/src/main/java/com/bitmovin/analytics/utils/LicenseCall.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/LicenseCall.java
@@ -31,7 +31,7 @@ public class LicenseCall {
         httpClient.post(json, new Callback() {
             @Override
             public void onFailure(Call call, IOException e) {
-                Log.d(TAG, "License call was denied", e);
+                Log.d(TAG, "License call failed due to connectivity issues", e);
                 callback.authenticationCompleted(false);
             }
 


### PR DESCRIPTION
### Work
- Fixes: https://github.com/bitmovin/analytics-issues/issues/660
- Description: A NullPointerException could occur if the licensing backend did respond with a malformed message that doesn't contain a json response body with a `message` payload. (The logmessage was calling `getMessage()` without checking nullability.

### Checklist

- [x] Updated CHANGELOG.md
