### PR TITLE
AN-949 removed Heartbeat activation in Pause State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - player started state transition before the player was ready
+- pause state activated heartbeat and sent out unnecessary payload 
 
 ## v1.10.0
 

--- a/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerState.java
+++ b/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerState.java
@@ -75,7 +75,7 @@ public enum PlayerState {
                 }
             }
 
-            machine.enableHeartbeat();
+//            machine.enableHeartbeat();
 
         }
 
@@ -86,7 +86,7 @@ public enum PlayerState {
                 listener.onPauseExit(timeStamp - enterTimestamp);
             }
 
-            machine.disableHeartbeat();
+//            machine.disableHeartbeat();
         }
     },
     QUALITYCHANGE {


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-949
- Description: during pause state the heartbeat was activated and sent out Samples
Removed the activation of hearbeat in the pause state

### Checklist

- [x] Updated CHANGELOG.md
