### PR TITLE
AN-966 Fixed exoplayer-collector crash when modules have not been loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
+### Fixed
+- exoplayer collector crashes when specific exoplayer modules have not been loaded (AN-966)
+
 ## v1.11.0
 
 ### Added 

--- a/analyticsexample/src/main/java/com/bitmovin/exoplayeranalyticsexample/MainActivity.java
+++ b/analyticsexample/src/main/java/com/bitmovin/exoplayeranalyticsexample/MainActivity.java
@@ -102,7 +102,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             bitmovinAnalytics.attachPlayer(player);
 
 
-            //Step 5: Create, prepeare, and play media source
+            //Step 5: Create, prepare, and play media source
             playerView.setPlayer(player);
 
             Uri dashStatic = Uri.parse("http://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd");

--- a/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
+++ b/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
@@ -69,25 +69,16 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
         attachAnalyticsListener();
     }
 
-    private boolean isClassLoaded(String className) {
-        try {
-            Class.forName(className);
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
-    }
-
     private boolean isHlsManifestClassLoaded(){
         if (this._isHlsManifestClassLoaded == null) {
-            this._isHlsManifestClassLoaded = this.isClassLoaded(HLS_MANIFEST_CLASSNAME);
+            this._isHlsManifestClassLoaded = Util.isClassLoaded(HLS_MANIFEST_CLASSNAME);
         }
         return this._isHlsManifestClassLoaded;
     }
 
     private boolean isDashManifestClassLoaded(){
         if (this._isDashManifestClassLoaded == null) {
-            this._isDashManifestClassLoaded = this.isClassLoaded(DASH_MANIFEST_CLASSNAME);
+            this._isDashManifestClassLoaded = Util.isClassLoaded(DASH_MANIFEST_CLASSNAME);
         }
         return this._isDashManifestClassLoaded;
     }

--- a/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerModule.kt
+++ b/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerModule.kt
@@ -1,0 +1,7 @@
+package com.bitmovin.analytics.exoplayer
+
+enum class ExoPlayerModule(val moduleName: String) {
+    HLS("goog.exo.hls"),
+    DASH("goog.exo.dash"),
+    SMOOTH_STREAMING("goog.exo.smoothstreaming")
+}

--- a/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerModule.kt
+++ b/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerModule.kt
@@ -1,7 +1,0 @@
-package com.bitmovin.analytics.exoplayer
-
-enum class ExoPlayerModule(val moduleName: String) {
-    HLS("goog.exo.hls"),
-    DASH("goog.exo.dash"),
-    SMOOTH_STREAMING("goog.exo.smoothstreaming")
-}

--- a/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
@@ -110,4 +110,13 @@ public class Util {
         }
         return isLiveFromConfig;
     }
+
+    public static boolean isClassLoaded(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-966
- Description: Check which exoplayer modules (DASH, HLS) are loaded before checking the manifest type 

### Checklist

- [x] Updated CHANGELOG.md
