### PR TITLE
AN-1047 - Using videoDuration for videoTimeEnd in PlaybackFinished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
+### Changed
+
+- `PlaybackFinished` event will set the `videoTimeEnd` to `videoDuration`, as `currentTime` might not be accurate due to rounding errors
+
 ## v1.11.0
 
 ### Added 

--- a/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
+++ b/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
@@ -265,7 +265,9 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         @Override
         public void onPlaybackFinished(PlaybackFinishedEvent playbackFinishedEvent) {
             Log.d(TAG, "On Playback Finished Listener");
-            stateMachine.transitionState(PlayerState.PAUSE, getPosition());
+
+            long position = (bitmovinPlayer.getDuration() != Double.POSITIVE_INFINITY) ? (long) bitmovinPlayer.getDuration() * Util.MILLISECONDS_IN_SECONDS : getPosition();
+            stateMachine.transitionState(PlayerState.PAUSE, position);
             stateMachine.disableHeartbeat();
 
         }


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-1047
- Description: Using videoDuration for videoTimeEnd in PlaybackFinished to avoid rounding errors

### Checklist

- [x] Updated CHANGELOG.md
