### PR TITLE
AN-1068 fix empty mpd url in sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
+### Fixed
+
+- empty MPD URL when manifest location is null (AN-1068)
+- exoplayer demo crash when calling `releasePlayer()`
+
 ## v1.11.1
 
 ### Changed

--- a/analyticsexample/src/main/java/com/bitmovin/exoplayeranalyticsexample/MainActivity.java
+++ b/analyticsexample/src/main/java/com/bitmovin/exoplayeranalyticsexample/MainActivity.java
@@ -97,6 +97,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
             //Step 3: Create Analytics Collector
             ExoPlayerCollector bitmovinAnalytics = new ExoPlayerCollector(bitmovinAnalyticsConfig, getApplicationContext());
+            this.bitmovinAnalytics = bitmovinAnalytics;
 
             //Step 4: Attach ExoPlayer
             bitmovinAnalytics.attachPlayer(player);

--- a/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
+++ b/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
@@ -1,5 +1,6 @@
 package com.bitmovin.analytics.exoplayer;
 
+import static com.google.android.exoplayer2.C.DATA_TYPE_MANIFEST;
 import static com.google.android.exoplayer2.C.TIME_UNSET;
 import static com.google.android.exoplayer2.C.TRACK_TYPE_AUDIO;
 import static com.google.android.exoplayer2.C.TRACK_TYPE_VIDEO;
@@ -55,6 +56,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
     private PlayerStateMachine stateMachine;
     private int totalDroppedVideoFrames;
     private boolean playerIsReady;
+    private String manifestUrl;
     private ExceptionMapper<Throwable> exceptionMapper = new ExoPlayerExceptionMapper();
     private final EventDataFactory factory;
 
@@ -92,6 +94,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
 
     public void release() {
         playerIsReady = false;
+        manifestUrl = null;
         if (this.exoplayer != null) {
             this.exoplayer.removeListener(this);
         }
@@ -243,7 +246,9 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
             DashManifest dashManifest;
             dashManifest = (DashManifest) manifest;
             data.setStreamFormat(Util.DASH_STREAM_FORMAT);
-            if (dashManifest.location != null) {
+            if (dashManifest.location == null) {
+                data.setMpdUrl(this.manifestUrl);
+            } else {
                 data.setMpdUrl(dashManifest.location.toString());
             }
         } else if (isHlsManifestClassLoaded() && manifest instanceof HlsManifest) {
@@ -343,7 +348,9 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
 
     @Override
     public void onLoadCompleted(EventTime eventTime, MediaSourceEventListener.LoadEventInfo loadEventInfo, MediaSourceEventListener.MediaLoadData mediaLoadData) {
-
+        if (mediaLoadData.dataType == DATA_TYPE_MANIFEST) {
+            this.manifestUrl = loadEventInfo.dataSpec.uri.toString();
+        }
     }
 
     @Override


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-1068
- Description:
    - Grab manifest location from the `onLoadComplete` event and use it as a fallback if `manifest.location` is null
    - Fixed exoplayer demo crashing when calling `releasePlayer()`

### Checklist

- [x] Updated CHANGELOG.md
