### PR TITLE
AN-972 - Improved duration tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - empty MPD URL when manifest location is null (AN-1068)
 - exoplayer demo crash when calling `releasePlayer()`
+- Time difference calculation now uses `SystemClock.elapsedRealtime()` to be immune to changes of the phone's date
 
 ## v1.11.1
 

--- a/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
+++ b/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
@@ -278,7 +278,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         public void onPaused(PausedEvent pausedEvent) {
             Log.d(TAG, "On Pause Listener");
             //Do not transition to a paused state unless a firstReadyTimestamp has been set. This will be set by the onReadyListener and prevents the player from showing inaccurate startup times
-            if (stateMachine.getFirstReadyTimestamp() != 0) {
+            if (stateMachine.getElapsedTimeFirstReady() != 0) {
                 stateMachine.transitionState(PlayerState.PAUSE, getPosition());
             }
         }
@@ -289,7 +289,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         public void onPlay(PlayEvent playEvent) {
             Log.d(TAG, "On Play Listener");
             //Do not transition to a playing state unless a firstReadyTimestamp has been set. This will be set by the onReadyListener and prevents the player from showing inaccurate startup times when autopplay is enabled
-            if (stateMachine.getFirstReadyTimestamp() != 0) {
+            if (stateMachine.getElapsedTimeFirstReady() != 0) {
                 stateMachine.transitionState(PlayerState.PLAYING, getPosition());
             }
         }
@@ -306,7 +306,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         @Override
         public void onSeek(SeekEvent seekEvent) {
             Log.d(TAG, "On Seek Listener");
-            if (stateMachine.getCurrentState() != PlayerState.SEEKING && stateMachine.getFirstReadyTimestamp() != 0) {
+            if (stateMachine.getCurrentState() != PlayerState.SEEKING && stateMachine.getElapsedTimeFirstReady() != 0) {
                 stateMachine.transitionState(PlayerState.SEEKING, getPosition());
             }
         }
@@ -316,7 +316,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         @Override
         public void onStallEnded(StallEndedEvent stallEndedEvent) {
             Log.d(TAG, "On Stall Ended: " + String.valueOf(bitmovinPlayer.isPlaying()));
-            if(stateMachine.getFirstReadyTimestamp() != 0) {
+            if(stateMachine.getElapsedTimeFirstReady() != 0) {
                 if (bitmovinPlayer.isPlaying() && stateMachine.getCurrentState() != PlayerState.PLAYING) {
                     stateMachine.transitionState(PlayerState.PLAYING, getPosition());
                 } else if (bitmovinPlayer.isPaused() && stateMachine.getCurrentState() != PlayerState.PAUSE) {
@@ -330,7 +330,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         @Override
         public void onAudioChanged(AudioChangedEvent audioChangedEvent) {
             Log.d(TAG, "On AudioChanged: " + bitmovinPlayer.getAudio().getId());
-            if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.getFirstReadyTimestamp() != 0) {
+            if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.getElapsedTimeFirstReady() != 0) {
                 PlayerState originalState = stateMachine.getCurrentState();
                 stateMachine.transitionState(PlayerState.AUDIOTRACKCHANGE, getPosition());
                 stateMachine.transitionState(originalState, getPosition());
@@ -342,7 +342,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         @Override
         public void onSubtitleChanged(SubtitleChangedEvent event) {
             Log.d(TAG, "On SubtitleChanged: " + bitmovinPlayer.getSubtitle().getId());
-            if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.getFirstReadyTimestamp() != 0) {
+            if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.getElapsedTimeFirstReady() != 0) {
                 PlayerState originalState = stateMachine.getCurrentState();
                 stateMachine.transitionState(PlayerState.SUBTITLECHANGE, getPosition());
                 stateMachine.transitionState(originalState, getPosition());
@@ -354,7 +354,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         @Override
         public void onStallStarted(StallStartedEvent stallStartedEvent) {
             Log.d(TAG, "On Stall Started Listener");
-            if (stateMachine.getCurrentState() != PlayerState.SEEKING && stateMachine.getFirstReadyTimestamp() != 0) {
+            if (stateMachine.getCurrentState() != PlayerState.SEEKING && stateMachine.getElapsedTimeFirstReady() != 0) {
                 stateMachine.transitionState(PlayerState.BUFFERING, getPosition());
             }
         }
@@ -365,7 +365,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         public void onVideoPlaybackQualityChanged(
             VideoPlaybackQualityChangedEvent videoPlaybackQualityChangedEvent) {
             Log.d(TAG, "On Video Quality Changed");
-            if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.getFirstReadyTimestamp() != 0) {
+            if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.getElapsedTimeFirstReady() != 0) {
                 PlayerState originalState = stateMachine.getCurrentState();
                 stateMachine.transitionState(PlayerState.QUALITYCHANGE, getPosition());
                 stateMachine.transitionState(originalState, getPosition());
@@ -385,7 +385,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         public void onAudioPlaybackQualityChanged(
             AudioPlaybackQualityChangedEvent audioPlaybackQualityChangedEvent) {
             Log.d(TAG, "On Audio Quality Changed");
-            if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.getFirstReadyTimestamp() != 0) {
+            if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.getElapsedTimeFirstReady() != 0) {
                 PlayerState originalState = stateMachine.getCurrentState();
                 stateMachine.transitionState(PlayerState.QUALITYCHANGE, getPosition());
                 stateMachine.transitionState(originalState, getPosition());

--- a/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
+++ b/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
@@ -152,7 +152,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
                 }
                 break;
             case Player.STATE_BUFFERING:
-                if (this.stateMachine.getCurrentState() != PlayerState.SEEKING && this.stateMachine.getFirstReadyTimestamp() != 0) {
+                if (this.stateMachine.getCurrentState() != PlayerState.SEEKING && this.stateMachine.getElapsedTimeFirstReady() != 0) {
                     this.stateMachine.transitionState(PlayerState.BUFFERING, videoTime);
                 }
                 break;

--- a/collector/src/main/java/com/bitmovin/analytics/BitmovinAdAnalytics.kt
+++ b/collector/src/main/java/com/bitmovin/analytics/BitmovinAdAnalytics.kt
@@ -9,17 +9,17 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
     private var activeAdBreak: AdBreak? = null
     private var activeAdSample: AdSample? = null
     private var adPodPosition: Int = 0
-    private var adStartupTimestamp: Long? = null
-    private var beginPlayingTimestamp: Long? = null
+    private var elapsedTimeAdStartup: Long? = null
+    private var elapsedTimeBeginPlaying: Long? = null
     private var isPlaying: Boolean = false
     private val adManifestDownloadTimes: HashMap<String, Long> = hashMapOf()
 
     private var currentTime: Long? = null
         get() = if(this.isPlaying) {
-            if(field == null || this.beginPlayingTimestamp == null) {
+            if(field == null || this.elapsedTimeBeginPlaying == null) {
                 null
             } else {
-                field!! + Util.getElapsedTimestamp() - this.beginPlayingTimestamp!!
+                field!! + Util.getElapsedTime() - this.elapsedTimeBeginPlaying!!
             }
 
         } else {
@@ -33,8 +33,8 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
 
         this.resetActiveAd()
         val adSample = AdSample(ad = ad)
-        val adStartupTimestamp = this.adStartupTimestamp
-        adSample.adStartupTime = if (adStartupTimestamp != null) Util.getElapsedTimestamp() - adStartupTimestamp else null
+        val elapsedTimeAdStartup = this.elapsedTimeAdStartup
+        adSample.adStartupTime = if (elapsedTimeAdStartup != null) Util.getElapsedTime() - elapsedTimeAdStartup else null
 
         this.activeAdSample = adSample
 
@@ -54,7 +54,7 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
     fun onAdBreakStarted(adBreak: AdBreak) {
         this.adPodPosition = 0
         this.activeAdBreak = adBreak
-        this.adStartupTimestamp = Util.getElapsedTimestamp()
+        this.elapsedTimeAdStartup = Util.getElapsedTime()
     }
 
     fun onAdBreakFinished() {
@@ -93,8 +93,8 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
 
     fun onPlay() {
         if (this.analytics.adAdapter != null && this.analytics.adAdapter.isLinearAdActive && this.activeAdSample != null) {
-            val timestamp = Util.getElapsedTimestamp()
-            this.beginPlayingTimestamp = timestamp
+            val elapsedTime = Util.getElapsedTime()
+            this.elapsedTimeBeginPlaying = elapsedTime
             this.isPlaying = true
         }
     }
@@ -134,7 +134,7 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
         adSample.timePlayed = 0
         adSample.timeInViewport = 0
         adSample.adPodPosition = this.adPodPosition
-        this.beginPlayingTimestamp = Util.getElapsedTimestamp()
+        this.elapsedTimeBeginPlaying = Util.getElapsedTime()
         this.isPlaying = true
         this.currentTime = 0
         this.adPodPosition++
@@ -145,8 +145,8 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
         adSample.timePlayed = exitPosition
         adSample.playPercentage = Util.calculatePercentage(adSample.timePlayed, adSample.ad.duration, true)
 
-        // reset startupTimestamp for the next ad, in case there are multiple ads in one ad break
-        this.adStartupTimestamp = Util.getElapsedTimestamp()
+        // reset elapseedTimeAdStartup for the next ad, in case there are multiple ads in one ad break
+        this.elapsedTimeAdStartup = Util.getElapsedTime()
         this.isPlaying = false
         this.sendAnalyticsRequest(adBreak, adSample)
     }

--- a/collector/src/main/java/com/bitmovin/analytics/BitmovinAdAnalytics.kt
+++ b/collector/src/main/java/com/bitmovin/analytics/BitmovinAdAnalytics.kt
@@ -19,7 +19,7 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
             if(field == null || this.beginPlayingTimestamp == null) {
                 null
             } else {
-                field!! + Util.getTimeStamp() - this.beginPlayingTimestamp!!
+                field!! + Util.getElapsedTimestamp() - this.beginPlayingTimestamp!!
             }
 
         } else {
@@ -34,7 +34,7 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
         this.resetActiveAd()
         val adSample = AdSample(ad = ad)
         val adStartupTimestamp = this.adStartupTimestamp
-        adSample.adStartupTime = if (adStartupTimestamp != null) Util.getTimeStamp() - adStartupTimestamp else null
+        adSample.adStartupTime = if (adStartupTimestamp != null) Util.getElapsedTimestamp() - adStartupTimestamp else null
 
         this.activeAdSample = adSample
 
@@ -54,7 +54,7 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
     fun onAdBreakStarted(adBreak: AdBreak) {
         this.adPodPosition = 0
         this.activeAdBreak = adBreak
-        this.adStartupTimestamp = Util.getTimeStamp()
+        this.adStartupTimestamp = Util.getElapsedTimestamp()
     }
 
     fun onAdBreakFinished() {
@@ -93,7 +93,7 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
 
     fun onPlay() {
         if (this.analytics.adAdapter != null && this.analytics.adAdapter.isLinearAdActive && this.activeAdSample != null) {
-            val timestamp = Util.getTimeStamp()
+            val timestamp = Util.getElapsedTimestamp()
             this.beginPlayingTimestamp = timestamp
             this.isPlaying = true
         }
@@ -134,7 +134,7 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
         adSample.timePlayed = 0
         adSample.timeInViewport = 0
         adSample.adPodPosition = this.adPodPosition
-        this.beginPlayingTimestamp = Util.getTimeStamp()
+        this.beginPlayingTimestamp = Util.getElapsedTimestamp()
         this.isPlaying = true
         this.currentTime = 0
         this.adPodPosition++
@@ -146,7 +146,7 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
         adSample.playPercentage = Util.calculatePercentage(adSample.timePlayed, adSample.ad.duration, true)
 
         // reset startupTimestamp for the next ad, in case there are multiple ads in one ad break
-        this.adStartupTimestamp = Util.getTimeStamp()
+        this.adStartupTimestamp = Util.getElapsedTimestamp()
         this.isPlaying = false
         this.sendAnalyticsRequest(adBreak, adSample)
     }
@@ -184,7 +184,7 @@ class BitmovinAdAnalytics(var analytics: BitmovinAnalytics) {
         eventData.setAdBreak(adBreak)
         eventData.setAdSample(adSample)
 
-        eventData.time = Util.getTimeStamp()
+        eventData.time = Util.getTimestamp()
         eventData.adImpressionId = Util.getUUID()
         analytics.sendAdEventData(eventData)
     }

--- a/collector/src/main/java/com/bitmovin/analytics/data/EventData.kt
+++ b/collector/src/main/java/com/bitmovin/analytics/data/EventData.kt
@@ -33,7 +33,7 @@ class EventData(bitmovinAnalyticsConfig: BitmovinAnalyticsConfig, val impression
     var isLive: Boolean = false
     var isCasting: Boolean = false
     var videoDuration: Long = 0
-    var time: Long = Util.getTimeStamp()
+    var time: Long = Util.getTimestamp()
     var videoWindowWidth: Int = 0
     var videoWindowHeight: Int = 0
     var droppedFrames: Int = 0

--- a/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerState.java
+++ b/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerState.java
@@ -10,7 +10,7 @@ public enum PlayerState {
         }
 
         @Override
-        void onExitState(PlayerStateMachine machine, long timeStamp, PlayerState desintationPlayerState) {
+        void onExitState(PlayerStateMachine machine, long elapsedTime, PlayerState desintationPlayerState) {
             for (StateMachineListener listener : machine.getListeners()) {
                 listener.onSetup();
             }
@@ -22,10 +22,10 @@ public enum PlayerState {
         }
 
         @Override
-        void onExitState(PlayerStateMachine machine, long timeStamp, PlayerState desintationPlayerState) {
+        void onExitState(PlayerStateMachine machine, long elapsedTime, PlayerState desintationPlayerState) {
             for (StateMachineListener listener : machine.getListeners()) {
-                long enterTimestamp = machine.getOnEnterStateTimeStamp();
-                listener.onRebuffering(timeStamp - enterTimestamp);
+                long elapsedTimeOnEnter = machine.getElapsedTimeOnEnter();
+                listener.onRebuffering(elapsedTime - elapsedTimeOnEnter);
             }
         }
     },
@@ -38,14 +38,14 @@ public enum PlayerState {
         }
 
         @Override
-        void onExitState(PlayerStateMachine machine, long timeStamp, PlayerState desintationPlayerState) {
+        void onExitState(PlayerStateMachine machine, long elapsedTime, PlayerState desintationPlayerState) {
         }
     },
     PLAYING {
         @Override
         void onEnterState(PlayerStateMachine machine) {
-            if (machine.getFirstReadyTimestamp() == 0) {
-                machine.setFirstReadyTimestamp(Util.getElapsedTimestamp());
+            if (machine.getElapsedTimeFirstReady() == 0) {
+                machine.setElapsedTimeFirstReady(Util.getElapsedTime());
                 for (StateMachineListener listener : machine.getListeners()) {
                     listener.onStartup(machine.getStartupTime());
                 }
@@ -55,10 +55,10 @@ public enum PlayerState {
         }
 
         @Override
-        void onExitState(PlayerStateMachine machine, long timeStamp, PlayerState desintationPlayerState) {
+        void onExitState(PlayerStateMachine machine, long elapsedTime, PlayerState desintationPlayerState) {
             for (StateMachineListener listener : machine.getListeners()) {
-                long enterTimestamp = machine.getOnEnterStateTimeStamp();
-                listener.onPlayExit(timeStamp - enterTimestamp);
+                long elapsedTimeOnEnter = machine.getElapsedTimeOnEnter();
+                listener.onPlayExit(elapsedTime - elapsedTimeOnEnter);
             }
 
             machine.disableHeartbeat();
@@ -68,8 +68,8 @@ public enum PlayerState {
     PAUSE {
         @Override
         void onEnterState(PlayerStateMachine machine) {
-            if (machine.getFirstReadyTimestamp() == 0) {
-                machine.setFirstReadyTimestamp(Util.getElapsedTimestamp());
+            if (machine.getElapsedTimeFirstReady() == 0) {
+                machine.setElapsedTimeFirstReady(Util.getElapsedTime());
                 for (StateMachineListener listener : machine.getListeners()) {
                     listener.onStartup(machine.getStartupTime());
                 }
@@ -80,10 +80,10 @@ public enum PlayerState {
         }
 
         @Override
-        void onExitState(PlayerStateMachine machine, long timeStamp, PlayerState desintationPlayerState) {
+        void onExitState(PlayerStateMachine machine, long elapsedTime, PlayerState desintationPlayerState) {
             for (StateMachineListener listener : machine.getListeners()) {
-                long enterTimestamp = machine.getOnEnterStateTimeStamp();
-                listener.onPauseExit(timeStamp - enterTimestamp);
+                long elapsedTimeOnEnter = machine.getElapsedTimeOnEnter();
+                listener.onPauseExit(elapsedTime - elapsedTimeOnEnter);
             }
 
 //            machine.disableHeartbeat();
@@ -95,7 +95,7 @@ public enum PlayerState {
         }
 
         @Override
-        void onExitState(PlayerStateMachine machine, long timeStamp, PlayerState destinationPlayerState) {
+        void onExitState(PlayerStateMachine machine, long elapsedTime, PlayerState destinationPlayerState) {
             for (StateMachineListener listener : machine.getListeners()) {
                 listener.onQualityChange();
             }
@@ -107,7 +107,7 @@ public enum PlayerState {
         }
 
         @Override
-        void onExitState(PlayerStateMachine machine, long timeStamp, PlayerState destinationPlayerState) {
+        void onExitState(PlayerStateMachine machine, long elapsedTime, PlayerState destinationPlayerState) {
             for (StateMachineListener listener : machine.getListeners()) {
                 listener.onAudioTrackChange();
             }
@@ -119,7 +119,7 @@ public enum PlayerState {
         }
 
         @Override
-        void onExitState(PlayerStateMachine machine, long timeStamp, PlayerState destinationPlayerState) {
+        void onExitState(PlayerStateMachine machine, long elapsedTime, PlayerState destinationPlayerState) {
             for (StateMachineListener listener : machine.getListeners()) {
                 listener.onSubtitleChange();
             }
@@ -129,20 +129,20 @@ public enum PlayerState {
     SEEKING {
         @Override
         void onEnterState(PlayerStateMachine machine) {
-            machine.setSeekTimeStamp(machine.getOnEnterStateTimeStamp());
+            machine.setElapsedTimeSeekStart(machine.getElapsedTimeOnEnter());
         }
 
         @Override
-        void onExitState(PlayerStateMachine machine, long timeStamp, PlayerState destinationPlayerState) {
+        void onExitState(PlayerStateMachine machine, long elapsedTime, PlayerState destinationPlayerState) {
             for (StateMachineListener listener : machine.getListeners()) {
-                listener.onSeekComplete(timeStamp - machine.getSeekTimeStamp());
+                listener.onSeekComplete(elapsedTime - machine.getElapsedTimeSeekStart());
             }
-            machine.setSeekTimeStamp(0);
+            machine.setElapsedTimeSeekStart(0);
         }
     };
 
     abstract void onEnterState(PlayerStateMachine machine);
 
-    abstract void onExitState(PlayerStateMachine machine, long timeStamp, PlayerState desintationPlayerState);
+    abstract void onExitState(PlayerStateMachine machine, long elapsedTime, PlayerState desintationPlayerState);
 
 }

--- a/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerState.java
+++ b/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerState.java
@@ -45,7 +45,7 @@ public enum PlayerState {
         @Override
         void onEnterState(PlayerStateMachine machine) {
             if (machine.getFirstReadyTimestamp() == 0) {
-                machine.setFirstReadyTimestamp(Util.getTimeStamp());
+                machine.setFirstReadyTimestamp(Util.getElapsedTimestamp());
                 for (StateMachineListener listener : machine.getListeners()) {
                     listener.onStartup(machine.getStartupTime());
                 }
@@ -69,7 +69,7 @@ public enum PlayerState {
         @Override
         void onEnterState(PlayerStateMachine machine) {
             if (machine.getFirstReadyTimestamp() == 0) {
-                machine.setFirstReadyTimestamp(Util.getTimeStamp());
+                machine.setFirstReadyTimestamp(Util.getElapsedTimestamp());
                 for (StateMachineListener listener : machine.getListeners()) {
                     listener.onStartup(machine.getStartupTime());
                 }

--- a/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerStateMachine.java
+++ b/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerStateMachine.java
@@ -16,10 +16,10 @@ public class PlayerStateMachine {
     private final BitmovinAnalyticsConfig config;
     private List<StateMachineListener> listeners = new ArrayList<StateMachineListener>();
     private PlayerState currentState;
-    private long initialTimestamp = 0;
-    private long firstReadyTimestamp = 0;
-    private long onEnterStateTimeStamp = 0;
-    private long seekTimeStamp = 0;
+    private long elaspedTimeInitial = 0;
+    private long elapsedTimeFirstReady = 0;
+    private long elapsedTimeOnEnter = 0;
+    private long elapsedTimeSeekStart = 0;
     private long videoTimeStart;
     private long videoTimeEnd;
     private ErrorCode errorCode;
@@ -38,13 +38,13 @@ public class PlayerStateMachine {
     public void enableHeartbeat() {
         heartbeatHandler.postDelayed(new Runnable() {
             public void run() {
-                long currentTimestamp = Util.getElapsedTimestamp();
-                long enterTimestamp = getOnEnterStateTimeStamp();
+                long elapsedTime = Util.getElapsedTime();
+                long elapsedTimeOnEnter = getElapsedTimeOnEnter();
                 videoTimeEnd = analytics.getPosition();
                 for (StateMachineListener listener : getListeners()) {
-                    listener.onHeartbeat(currentTimestamp - enterTimestamp);
+                    listener.onHeartbeat(elapsedTime - elapsedTimeOnEnter);
                 }
-                onEnterStateTimeStamp = currentTimestamp;
+                PlayerStateMachine.this.elapsedTimeOnEnter = elapsedTime;
                 videoTimeStart = videoTimeEnd;
                 heartbeatHandler.postDelayed(this, heartbeatDelay);
             }
@@ -58,30 +58,30 @@ public class PlayerStateMachine {
     public void resetStateMachine() {
         disableHeartbeat();
         this.impressionId = Util.getUUID();
-        this.initialTimestamp = Util.getElapsedTimestamp();
-        this.firstReadyTimestamp = 0;
+        this.elaspedTimeInitial = Util.getElapsedTime();
+        this.elapsedTimeFirstReady = 0;
         setCurrentState(PlayerState.SETUP);
     }
 
     public synchronized void transitionState(PlayerState destinationPlayerState, long videoTime) {
-        long timeStamp = Util.getElapsedTimestamp();
+        long elapsedTime = Util.getElapsedTime();
         videoTimeEnd = videoTime;
 
         Log.d(TAG, "Transitioning from " + currentState.toString() + " to " + destinationPlayerState.toString());
 
-        currentState.onExitState(this, timeStamp, destinationPlayerState);
-        this.onEnterStateTimeStamp = timeStamp;
+        currentState.onExitState(this, elapsedTime, destinationPlayerState);
+        this.elapsedTimeOnEnter = elapsedTime;
         videoTimeStart = videoTimeEnd;
         destinationPlayerState.onEnterState(this);
         setCurrentState(destinationPlayerState);
     }
 
-    public long getFirstReadyTimestamp() {
-        return firstReadyTimestamp;
+    public long getElapsedTimeFirstReady() {
+        return elapsedTimeFirstReady;
     }
 
-    public void setFirstReadyTimestamp(long firstReadyTimestamp) {
-        this.firstReadyTimestamp = firstReadyTimestamp;
+    public void setElapsedTimeFirstReady(long elapsedTime) {
+        this.elapsedTimeFirstReady = elapsedTime;
     }
 
     public void addListener(StateMachineListener toAdd) {
@@ -105,7 +105,7 @@ public class PlayerStateMachine {
     }
 
     public long getStartupTime() {
-        return firstReadyTimestamp - initialTimestamp;
+        return elapsedTimeFirstReady - elaspedTimeInitial;
     }
 
     public String getImpressionId() {
@@ -120,16 +120,16 @@ public class PlayerStateMachine {
         return videoTimeEnd;
     }
 
-    public long getOnEnterStateTimeStamp() {
-        return onEnterStateTimeStamp;
+    public long getElapsedTimeOnEnter() {
+        return elapsedTimeOnEnter;
     }
 
-    public long getSeekTimeStamp() {
-        return seekTimeStamp;
+    public long getElapsedTimeSeekStart() {
+        return elapsedTimeSeekStart;
     }
 
-    public void setSeekTimeStamp(long seekTimeStamp) {
-        this.seekTimeStamp = seekTimeStamp;
+    public void setElapsedTimeSeekStart(long elapsedTimeSeekStart) {
+        this.elapsedTimeSeekStart = elapsedTimeSeekStart;
     }
 
     public ErrorCode getErrorCode() {

--- a/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerStateMachine.java
+++ b/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerStateMachine.java
@@ -38,7 +38,7 @@ public class PlayerStateMachine {
     public void enableHeartbeat() {
         heartbeatHandler.postDelayed(new Runnable() {
             public void run() {
-                long currentTimestamp = Util.getTimeStamp();
+                long currentTimestamp = Util.getElapsedTimestamp();
                 long enterTimestamp = getOnEnterStateTimeStamp();
                 videoTimeEnd = analytics.getPosition();
                 for (StateMachineListener listener : getListeners()) {
@@ -58,13 +58,13 @@ public class PlayerStateMachine {
     public void resetStateMachine() {
         disableHeartbeat();
         this.impressionId = Util.getUUID();
-        this.initialTimestamp = Util.getTimeStamp();
+        this.initialTimestamp = Util.getElapsedTimestamp();
         this.firstReadyTimestamp = 0;
         setCurrentState(PlayerState.SETUP);
     }
 
     public synchronized void transitionState(PlayerState destinationPlayerState, long videoTime) {
-        long timeStamp = Util.getTimeStamp();
+        long timeStamp = Util.getElapsedTimestamp();
         videoTimeEnd = videoTime;
 
         Log.d(TAG, "Transitioning from " + currentState.toString() + " to " + destinationPlayerState.toString());

--- a/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
@@ -48,6 +48,11 @@ public class Util {
                 Settings.Secure.ANDROID_ID);
     }
 
+    /**
+     * Returns the time in ms since the system was booted, and guaranteed to be monotonic
+     * Details here: https://developer.android.com/reference/android/os/SystemClock
+     * @return The time in ms since the system was booted, and guaranteed to be monotonic.
+     */
     public static long getElapsedTime() {
         return SystemClock.elapsedRealtime();
     }

--- a/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
@@ -48,7 +48,7 @@ public class Util {
                 Settings.Secure.ANDROID_ID);
     }
 
-    public static long getElapsedTimestamp() {
+    public static long getElapsedTime() {
         return SystemClock.elapsedRealtime();
     }
 

--- a/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
@@ -5,6 +5,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.res.Resources;
 import android.media.MediaCodecInfo;
 import android.media.MediaCodecList;
+import android.os.SystemClock;
 import android.provider.Settings;
 import android.util.Pair;
 
@@ -47,7 +48,11 @@ public class Util {
                 Settings.Secure.ANDROID_ID);
     }
 
-    public static long getTimeStamp() {
+    public static long getElapsedTimestamp() {
+        return SystemClock.elapsedRealtime();
+    }
+
+    public static long getTimestamp() {
         return System.currentTimeMillis();
     }
 


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-972
- Description: Hopefully fixes the problem with random samples having duration of around 20 years.
Initial thought was that the phone resets the time to 1.1.2000, but as the duration is positive, the phone's date is more likely in the future.
Nonetheless, this should improve how we calculate time differences, but we need to keep an eye on the data in future to see if this fixes the actual issue linked (@Tigraine)

### Checklist

- [x] Updated CHANGELOG.md
