### PR TITLE
AN-1092 fix crash if `isLive` was not set in the collector config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
+### Fixed
+
+- collector crash when `isLive` was not set in the analytics config (AN-1092)
+
 ## v1.11.2
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ bitmovinAnalyticsConfig.setCustomData4("customData4");
 bitmovinAnalyticsConfig.setCustomData5("customData5");
 bitmovinAnalyticsConfig.setCustomData6("customData6");
 bitmovinAnalyticsConfig.setCustomData7("customData7");
+bitmovinAnalyticsConfig.setIsLive(false);
 bitmovinAnalyticsConfig.setHeartbeatInterval(59700); // value is in ms 
 
 ```

--- a/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
@@ -114,11 +114,11 @@ public class Util {
         return new Pair<>(null, null);
     }
     
-    public static boolean getIsLiveFromConfigOrPlayer(boolean isPlayerReady, boolean isLiveFromConfig, boolean isLiveFromPlayer) {
+    public static boolean getIsLiveFromConfigOrPlayer(boolean isPlayerReady, Boolean isLiveFromConfig, boolean isLiveFromPlayer) {
         if (isPlayerReady) {
             return isLiveFromPlayer;
         }
-        return isLiveFromConfig;
+        return isLiveFromConfig != null ? isLiveFromConfig : false;
     }
 
     public static boolean isClassLoaded(String className) {


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-1092
- Description: Fixed collector crash when `isLive` was not set in the analytics config

### Checklist

- [x] Updated CHANGELOG.md
