### PR TITLE
AN-1281 fixed rebuffering after seek in exoplayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - heartbeat to Rebuffering state (AN-1281)
 
+### Fixed
+
+- no rebuffering state after seeking 
+
 ## v1.12.1
 
 ### Fixed

--- a/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
+++ b/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
@@ -169,7 +169,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
                 }
                 break;
             case Player.STATE_BUFFERING:
-                if (this.stateMachine.getCurrentState() != PlayerState.SEEKING && this.stateMachine.getElapsedTimeFirstReady() != 0) {
+                if (this.stateMachine.getElapsedTimeFirstReady() != 0) {
                     this.stateMachine.transitionState(PlayerState.BUFFERING, videoTime);
                 }
                 break;
@@ -210,8 +210,6 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
     @Override
     public void onPositionDiscontinuity(int reason) {
         Log.d(TAG, "onPositionDiscontinuity");
-        long videoTime = getPosition();
-        this.stateMachine.transitionState(PlayerState.SEEKING, videoTime);
     }
 
     @Override
@@ -320,7 +318,9 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
 
     @Override
     public void onSeekStarted(EventTime eventTime) {
-
+        Log.d(TAG, "onSeekStarted on position: " + eventTime.currentPlaybackPositionMs);
+        long videoTime = getPosition();
+        this.stateMachine.transitionState(PlayerState.SEEKING, videoTime);
     }
 
     @Override


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-1281
- Description: seek start event was listening in the wrong method

### Checklist

- [x] Updated CHANGELOG.md
