### PR TITLE
AN-1349 added check for androidTV on platform

### DIFF
--- a/collector/src/main/java/com/bitmovin/analytics/data/EventData.kt
+++ b/collector/src/main/java/com/bitmovin/analytics/data/EventData.kt
@@ -64,7 +64,7 @@ class EventData(bitmovinAnalyticsConfig: BitmovinAnalyticsConfig, val impression
     var progUrl: String? = null
     var isMuted = false
     var sequenceNumber: Int = 0
-    val platform: String = "android"
+    val platform: String = if(deviceInfo.isTV) "androidTV" else "android"
     var videoCodec: String? = null
     var audioCodec: String? = null
     var supportedVideoCodecs: List<String>? = null

--- a/collector/src/test/java/com/bitmovin/analytics/DeviceInformationDtoDataSerializationTest.kt
+++ b/collector/src/test/java/com/bitmovin/analytics/DeviceInformationDtoDataSerializationTest.kt
@@ -12,7 +12,7 @@ class DeviceInformationDtoDataSerializationTest {
         val config = BitmovinAnalyticsConfig("9ae0b480-f2ee-4c10-bc3c-cb88e982e0ac", "18ca6ad5-9768-4129-bdf6-17685e0d14d2")
         val model = "Pixel 3"
         val manufacturer = "Google"
-        val data = EventData(config, "1234", DeviceInformation(manufacturer, model, "user-agent", "de", "my.package", 100, 200), "user-id")
+        val data = EventData(config, "1234", DeviceInformation(manufacturer, model, false, "user-agent", "de", "my.package", 100, 200), "user-id")
         val serialized = DataSerializer.serialize(data)
 
         assertThat(serialized).contains("\"deviceInformation\":{")

--- a/collector/src/test/java/com/bitmovin/analytics/EventDataFactoryTest.kt
+++ b/collector/src/test/java/com/bitmovin/analytics/EventDataFactoryTest.kt
@@ -23,7 +23,7 @@ class EventDataFactoryTest {
     @Test
     fun testRetrievesDeviceInformationAndSetsItOnEventData() {
 
-        val deviceInfo = DeviceInformation("Foo", "Bar", "user-agent", "de", "package", 100, 200)
+        val deviceInfo = DeviceInformation("Foo", "Bar", false, "user-agent", "de", "package", 100, 200)
 
         val myMock = Mockito.mock(DeviceInformationProvider::class.java)
         Mockito.`when`(myMock.getDeviceInformation()).thenReturn(deviceInfo)
@@ -35,12 +35,25 @@ class EventDataFactoryTest {
         assertThat(eventData.userAgent).isEqualTo(deviceInfo.userAgent)
         assertThat(eventData.screenHeight).isEqualTo(deviceInfo.screenHeight)
         assertThat(eventData.screenWidth).isEqualTo(deviceInfo.screenWidth)
+        assertThat(eventData.platform).isEqualTo("android")
+    }
+    @Test
+    fun testAssignsDeviceInformationAndroidTVToEventData() {
+
+        val deviceInfo = DeviceInformation("Foo", "Bar", true, "user-agent", "de", "package", 100, 200)
+
+        val myMock = Mockito.mock(DeviceInformationProvider::class.java)
+        Mockito.`when`(myMock.getDeviceInformation()).thenReturn(deviceInfo)
+        val mockContext = Mockito.mock(Context::class.java)
+        val eventData: EventData = EventDataFactory(BitmovinAnalyticsConfig(), mockContext, myMock, userIdProvider).build("impression-id")
+
+        assertThat(eventData.platform).isEqualTo("androidTV")
     }
 
     @Test
     fun testAssignsDeviceInformationPackageNameAsDomainToEventData() {
 
-        val deviceInfo = DeviceInformation("Foo", "Bar", "user-agent", "de", "package", 100, 200)
+        val deviceInfo = DeviceInformation("Foo", "Bar", false, "user-agent", "de", "package", 100, 200)
 
         val myMock = Mockito.mock(DeviceInformationProvider::class.java)
         Mockito.`when`(myMock.getDeviceInformation()).thenReturn(deviceInfo)
@@ -52,7 +65,7 @@ class EventDataFactoryTest {
 
     @Test
     fun testRetrievesUserIdFromUserIdProviderAndAssignsToEventData() {
-        val deviceInfo = DeviceInformation("Foo", "Bar", "user-agent", "de", "package", 100, 200)
+        val deviceInfo = DeviceInformation("Foo", "Bar", false, "user-agent", "de", "package", 100, 200)
 
         val deviceInfoMock = Mockito.mock(DeviceInformationProvider::class.java)
         Mockito.`when`(deviceInfoMock.getDeviceInformation()).thenReturn(deviceInfo)
@@ -65,7 +78,7 @@ class EventDataFactoryTest {
 
     @Test
     fun testAssignsCorrectImpressionId() {
-        val deviceInfo = DeviceInformation("Foo", "Bar", "user-agent", "de", "package", 100, 200)
+        val deviceInfo = DeviceInformation("Foo", "Bar", false, "user-agent", "de", "package", 100, 200)
 
         val deviceInfoMock = Mockito.mock(DeviceInformationProvider::class.java)
         Mockito.`when`(deviceInfoMock.getDeviceInformation()).thenReturn(deviceInfo)


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-1349
- Description: check for TV on platform
  - save `androidTV` in platform for android TV devices

### Checklist

- [ ] Updated CHANGELOG.md (not need... follow up PR)
