### PR TITLE
AN-1348 AN-1397 audio codec not reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Change
 
 - support libraries changed to androidX libraries
+- getting audio codec data on BitmovinPlayer
 
 ## v1.13.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ ext {
     junitVersion = '4.12'
     testRunnerVersion = '1.0.1'
     espressoCoreVersion = '3.2.0'
-    playercoreVersion = '2.35.0'
+    playercoreVersion = '2.44.0'
     exoplayerVersion = '2.9.0'
     assertjCoreVersion = '3.11.1'
     mockitoCoreVersion = '2.7.22'

--- a/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdAdapter.kt
+++ b/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdAdapter.kt
@@ -112,6 +112,6 @@ class BitmovinSdkAdAdapter(val bitmovinPlayer: BitmovinPlayer, val adAnalytics: 
     override val moduleInformation: AdModuleInformation
         // TODO get actual module from player
         get() = AdModuleInformation("DefaultAdvertisingService", BitmovinUtil.getPlayerVersion())
-    override val isAutoplayEnabled: Boolean
-        get() = bitmovinPlayer.config.playbackConfiguration.isAutoplayEnabled
+    override val isAutoplayEnabled: Boolean?
+        get() = bitmovinPlayer.config.playbackConfiguration?.isAutoplayEnabled
 }

--- a/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
+++ b/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
@@ -235,8 +235,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         }
 
         //audio quality
-        //TODO change getAudioQuality to getAudioPlaybackData once available
-        AudioQuality audioQuality = bitmovinPlayer.getAudioQuality();
+        AudioQuality audioQuality = bitmovinPlayer.getPlaybackAudioData();
         if (audioQuality != null) {
             data.setAudioBitrate(audioQuality.getBitrate());
             data.setAudioCodec(audioQuality.getCodec());

--- a/collector/src/main/java/com/bitmovin/analytics/adapters/AdAdapter.kt
+++ b/collector/src/main/java/com/bitmovin/analytics/adapters/AdAdapter.kt
@@ -6,5 +6,5 @@ interface AdAdapter {
     fun release()
     val isLinearAdActive: Boolean
     val moduleInformation: AdModuleInformation
-    val isAutoplayEnabled: Boolean
+    val isAutoplayEnabled: Boolean?
 }


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-1348
- Description: 
       - Updated version of bitmovin player,
       - Fixed build error due to bitmovinPlayer.config.playbackConfiguration being nullable. 
       - Replaced current method for getting audio codec data with new one
       - Also checked if everything is working  during Ad playback (https://bitmovin.atlassian.net/browse/AN-1397)

### Checklist

- [X] Updated CHANGELOG.md
