### PR TITLE
AN-1572 player crashed on ad error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
+### Fixed
+
+- bitmovin player crashed when `onAdError` was fired with empty ad tag url (AN-1572)
+
 ## v1.16.0
 
 ### Change
@@ -14,10 +18,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - don't send quality change sample if the quality did not change
 - Bitmovin, ExoPlayer: changed player error mapping to improve transparency (AN-1507)
 - set DRM information for each event data sent to server
-
-### Fixed
-
-- bitmovin player crashed when `onAdError` was fired with empty ad tag url (AN-1572)
 
 ## v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bitmovin, ExoPlayer: changed player error mapping to improve transparency (AN-1507)
 - set DRM information for each event data sent to server
 
+### Fixed
+
+- bitmovin player crashed when `onAdError` was fired with empty ad tag url (AN-1572)
+
 ## v1.15.0
 
 ### Added

--- a/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
@@ -105,7 +105,7 @@ public class Util {
         try {
             URI uri = new URI(uriString);
             return new Pair<>(uri.getHost(), uri.getPath());
-        } catch (URISyntaxException ignored) {
+        } catch (Exception ignored) {
 
         }
         return new Pair<>(null, null);


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-1572
- Description: NullPointerException occurred when the ad tag url was `null`. Fixed by ignoring all exceptions in the corresponding catch statement.

### Checklist

- [x] Updated CHANGELOG.md
