### PR TITLE
AN-1595 Cleanup Timer memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
+### Fixed
+
+- `CountDownTimer` potentially continues running after the player adapter is released (AN-1595) 
+
 ## v1.16.0
 
 ### Change

--- a/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
+++ b/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
@@ -236,6 +236,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         if (bitmovinPlayer != null) {
             removePlayerListener();
         }
+        videoStartTimeout.cancel();
     }
 
     @Override

--- a/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
+++ b/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
@@ -139,6 +139,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
             simpleExoPlayer.removeAnalyticsListener(this);
         }
         meter.reset();
+        videoStartTimeout.cancel();
     }
 
     @Override


### PR DESCRIPTION
### Work
- Fixes: AN-1595
- Description: Cleanup memory by canceling potentially running `CountDownTimer` in the player adapter. The `Timer` should be properly canceled, once the player adapter is released, to avoid unneeded memory allocation past the `PlayerAdapter.release()` call.

### Checklist

- [x] Updated CHANGELOG.md
