### PR TITLE
AN-1559 threshold buffering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v1.17.0
 
+### Added
+
+- Timeout for rebuffering event (AN-1559)
+
 ### Changed
 - tracking of video startup times when having autoplay enabled to be consistent with web platform 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Restricted number of quality changes tracked per period of time (AN-1560)
+- Timeout for rebuffering event (AN-1559)
 
 ## v1.17.0
-
-### Added
-
-- Timeout for rebuffering event (AN-1559)
 
 ### Changed
 - tracking of video startup times when having autoplay enabled to be consistent with web platform 

--- a/collector/src/main/java/com/bitmovin/analytics/enums/AnalyticsErrorCodes.kt
+++ b/collector/src/main/java/com/bitmovin/analytics/enums/AnalyticsErrorCodes.kt
@@ -1,0 +1,8 @@
+package com.bitmovin.analytics.enums
+
+import com.bitmovin.analytics.data.ErrorCode
+
+enum class AnalyticsErrorCodes(val errorCode: ErrorCode) {
+    ANALYTICS_QUALITY_CHANGE_THRESHOLD_EXCEEDED( ErrorCode(10000, "ANALYTICS_QUALITY_CHANGE_THRESHOLD_EXCEEDED", null)),
+    ANALYTICS_BUFFERING_TIMEOUT_REACHED(ErrorCode(10001, "ANALYTICS_BUFFERING_TIMEOUT_REACHED", null))
+}

--- a/collector/src/main/java/com/bitmovin/analytics/enums/AnalyticsErrorCodes.kt
+++ b/collector/src/main/java/com/bitmovin/analytics/enums/AnalyticsErrorCodes.kt
@@ -3,6 +3,6 @@ package com.bitmovin.analytics.enums
 import com.bitmovin.analytics.data.ErrorCode
 
 enum class AnalyticsErrorCodes(val errorCode: ErrorCode) {
-    ANALYTICS_QUALITY_CHANGE_THRESHOLD_EXCEEDED( ErrorCode(10000, "ANALYTICS_QUALITY_CHANGE_THRESHOLD_EXCEEDED", null)),
+    ANALYTICS_QUALITY_CHANGE_THRESHOLD_EXCEEDED(ErrorCode(10000, "ANALYTICS_QUALITY_CHANGE_THRESHOLD_EXCEEDED", null)),
     ANALYTICS_BUFFERING_TIMEOUT_REACHED(ErrorCode(10001, "ANALYTICS_BUFFERING_TIMEOUT_REACHED", null))
 }

--- a/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerState.java
+++ b/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerState.java
@@ -53,6 +53,7 @@ public enum PlayerState {
         @Override
         void onEnterState(PlayerStateMachine machine) {
             machine.enableRebufferHeartbeat();
+            machine.rebufferingTimeout.start();
         }
 
         @Override
@@ -62,6 +63,7 @@ public enum PlayerState {
                 long elapsedTimeOnEnter = machine.getElapsedTimeOnEnter();
                 listener.onRebuffering(elapsedTime - elapsedTimeOnEnter);
             }
+            machine.rebufferingTimeout.cancel();
         }
     },
     ERROR {

--- a/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerStateMachine.java
+++ b/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerStateMachine.java
@@ -7,6 +7,7 @@ import android.util.Log;
 import com.bitmovin.analytics.BitmovinAnalytics;
 import com.bitmovin.analytics.BitmovinAnalyticsConfig;
 import com.bitmovin.analytics.data.ErrorCode;
+import com.bitmovin.analytics.enums.AnalyticsErrorCodes;
 import com.bitmovin.analytics.enums.VideoStartFailedReason;
 import com.bitmovin.analytics.utils.Util;
 
@@ -118,6 +119,10 @@ public class PlayerStateMachine {
         }
         // no state transitions like PLAYING or PAUSE during AD
         else if (currentState == PlayerState.AD && (destination != PlayerState.ERROR && destination != PlayerState.ADFINISHED )) {
+            return false;
+        }
+        else if(currentState == PlayerState.READY && (destination != PlayerState.ERROR && destination != PlayerState.EXITBEFOREVIDEOSTART &&
+                destination != PlayerState.STARTUP && destination != PlayerState.AD)){
             return false;
         }
 
@@ -265,6 +270,7 @@ public class PlayerStateMachine {
             setErrorCode(AnalyticsErrorCodes.ANALYTICS_BUFFERING_TIMEOUT_REACHED.getErrorCode());
             transitionState(PlayerState.ERROR, analytics.getPosition());
             disableRebufferHeartbeat();
+            resetStateMachine();
         }
 
     };

--- a/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerStateMachine.java
+++ b/collector/src/main/java/com/bitmovin/analytics/stateMachines/PlayerStateMachine.java
@@ -7,6 +7,7 @@ import android.util.Log;
 import com.bitmovin.analytics.BitmovinAnalytics;
 import com.bitmovin.analytics.BitmovinAnalyticsConfig;
 import com.bitmovin.analytics.data.ErrorCode;
+import com.bitmovin.analytics.enums.AnalyticsErrorCodes;
 import com.bitmovin.analytics.enums.VideoStartFailedReason;
 import com.bitmovin.analytics.utils.Util;
 
@@ -87,6 +88,7 @@ public class PlayerStateMachine {
         startupTime = 0;
         startupFinished = false;
         videoStartTimeout.cancel();
+        rebufferingTimeout.cancel();
         setCurrentState(PlayerState.READY);
     }
 
@@ -221,6 +223,22 @@ public class PlayerStateMachine {
         transitionState(PlayerState.AD, position);
         startupTime = 0;
     }
+
+    protected CountDownTimer rebufferingTimeout = new CountDownTimer(Util.REBUFFERING_TIMEOUT, 1000) {
+        @Override
+        public void onTick(long millisUntilFinished) {
+        }
+
+        @Override
+        public void onFinish() {
+            Log.d(TAG, "rebufferingTimeout finish");
+            setErrorCode(AnalyticsErrorCodes.ANALYTICS_BUFFERING_TIMEOUT_REACHED.getErrorCode());
+            transitionState(PlayerState.ERROR, analytics.getPosition());
+            disableRebufferHeartbeat();
+        }
+
+    };
+
 }
 
 

--- a/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
+++ b/collector/src/main/java/com/bitmovin/analytics/utils/Util.java
@@ -23,6 +23,7 @@ public class Util {
     public static final String SMOOTH_STREAM_FORMAT = "smooth";
     public static final int MILLISECONDS_IN_SECONDS = 1000;
     public static final int VIDEOSTART_TIMEOUT = 1000 * 60; // in milliseconds
+    public static final int REBUFFERING_TIMEOUT = 1000 * 60 * 2; // in milliseconds
 
     private static final Map<String, String> VIDEO_FORMAT_MIME_TYPE_MAP;
     public static final String PLAYER_TECH = "Android:Exoplayer";


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-1559
- Description: Added timeout for rebuffering event.

`AnalyticsErrorCodes` class and canceling of rebufferi timer is the same as in restrict quality changes PR (https://github.com/bitmovin/bitmovin-analytics-collector-android/pull/116)

### Checklist

- [X] Updated CHANGELOG.md
