### PR TITLE
AN-1506 device available width and height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Development
 
 ### Changed
-- Way of getting available screen width and height
+- Calculations for available screen width and height to now include screen density and be more independent of physical pixel
 
 ## v1.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Development
 
+### Changed
+- Way of getting available screen width and height
+
 ## v1.18.0
 
 ### Added
 
 - Restricted number of quality changes tracked per period of time (AN-1560)
 - Timeout for rebuffering event (AN-1559)
-
-### Changed
-- Getting available screen dimensions
 
 ## v1.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Restricted number of quality changes tracked per period of time (AN-1560)
 - Timeout for rebuffering event (AN-1559)
 
+### Changed
+- Getting available screen dimensions
+
 ## v1.17.0
 
 ### Changed

--- a/collector/src/main/java/com/bitmovin/analytics/data/DeviceInformationProvider.kt
+++ b/collector/src/main/java/com/bitmovin/analytics/data/DeviceInformationProvider.kt
@@ -3,16 +3,14 @@ package com.bitmovin.analytics.data
 import android.app.UiModeManager
 import android.content.Context
 import android.content.res.Configuration
-
 import android.os.Build
 import android.util.DisplayMetrics
 import android.view.WindowManager
 import com.bitmovin.analytics.utils.Util
 import kotlin.math.roundToInt
 
-
 open class DeviceInformationProvider(val context: Context, val userAgent: String) {
-   var isTV: Boolean = isTVDevice()
+    var isTV: Boolean = isTVDevice()
 
     private val windowManager: WindowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     private val displayMetrics = DisplayMetrics()
@@ -22,7 +20,6 @@ open class DeviceInformationProvider(val context: Context, val userAgent: String
 
     val width = (configuration.screenWidthDp * displayMetrics.density).roundToInt()
     val height = (configuration.screenHeightDp * displayMetrics.density).roundToInt()
-
 
     fun getDeviceInformation(): DeviceInformation {
         return DeviceInformation(

--- a/collector/src/main/java/com/bitmovin/analytics/data/DeviceInformationProvider.kt
+++ b/collector/src/main/java/com/bitmovin/analytics/data/DeviceInformationProvider.kt
@@ -16,11 +16,15 @@ open class DeviceInformationProvider(val context: Context, val userAgent: String
 
         val windowManager: WindowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
         val displayMetrics = DisplayMetrics()
+        var width: Int = 0
+        var height: Int = 0
 
-        windowManager.defaultDisplay.getMetrics(displayMetrics)
+        if (windowManager != null) {
+            windowManager.defaultDisplay.getMetrics(displayMetrics)
 
-        val width = (displayMetrics.widthPixels / displayMetrics.density).roundToInt()
-        val height = (displayMetrics.heightPixels / displayMetrics.density).roundToInt()
+            width = (displayMetrics.widthPixels / displayMetrics.density).roundToInt()
+            height = (displayMetrics.heightPixels / displayMetrics.density).roundToInt()
+        }
 
         return DeviceInformation(
                 manufacturer = Build.MANUFACTURER,

--- a/collector/src/main/java/com/bitmovin/analytics/data/DeviceInformationProvider.kt
+++ b/collector/src/main/java/com/bitmovin/analytics/data/DeviceInformationProvider.kt
@@ -3,11 +3,26 @@ package com.bitmovin.analytics.data
 import android.app.UiModeManager
 import android.content.Context
 import android.content.res.Configuration
+
 import android.os.Build
+import android.util.DisplayMetrics
+import android.view.WindowManager
 import com.bitmovin.analytics.utils.Util
+import kotlin.math.roundToInt
+
 
 open class DeviceInformationProvider(val context: Context, val userAgent: String) {
-    var isTV: Boolean = isTVDevice()
+   var isTV: Boolean = isTVDevice()
+
+    private val windowManager: WindowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    private val displayMetrics = DisplayMetrics()
+
+    val res = windowManager.defaultDisplay.getMetrics(displayMetrics)
+    val configuration: Configuration = context.resources.configuration
+
+    val width = (configuration.screenWidthDp * displayMetrics.density).roundToInt()
+    val height = (configuration.screenHeightDp * displayMetrics.density).roundToInt()
+
 
     fun getDeviceInformation(): DeviceInformation {
         return DeviceInformation(
@@ -16,8 +31,8 @@ open class DeviceInformationProvider(val context: Context, val userAgent: String
                 isTV = isTV,
                 locale = Util.getLocale(),
                 packageName = context.packageName,
-                screenWidth = context?.getResources()?.getDisplayMetrics()?.widthPixels ?: 0,
-                screenHeight = context?.getResources()?.getDisplayMetrics()?.heightPixels ?: 0,
+                screenWidth = width,
+                screenHeight = height,
                 userAgent = userAgent
         )
     }

--- a/collector/src/main/java/com/bitmovin/analytics/data/DeviceInformationProvider.kt
+++ b/collector/src/main/java/com/bitmovin/analytics/data/DeviceInformationProvider.kt
@@ -12,16 +12,16 @@ import kotlin.math.roundToInt
 open class DeviceInformationProvider(val context: Context, val userAgent: String) {
     var isTV: Boolean = isTVDevice()
 
-    private val windowManager: WindowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-    private val displayMetrics = DisplayMetrics()
-
-    val res = windowManager.defaultDisplay.getMetrics(displayMetrics)
-    val configuration: Configuration = context.resources.configuration
-
-    val width = (configuration.screenWidthDp * displayMetrics.density).roundToInt()
-    val height = (configuration.screenHeightDp * displayMetrics.density).roundToInt()
-
     fun getDeviceInformation(): DeviceInformation {
+
+        val windowManager: WindowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        val displayMetrics = DisplayMetrics()
+
+        windowManager.defaultDisplay.getMetrics(displayMetrics)
+
+        val width = (displayMetrics.widthPixels / displayMetrics.density).roundToInt()
+        val height = (displayMetrics.heightPixels / displayMetrics.density).roundToInt()
+
         return DeviceInformation(
                 manufacturer = Build.MANUFACTURER,
                 model = Build.MODEL,


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-1506
- Description: 

https://developer.android.com/reference/android/view/WindowManager#getDefaultDisplay()
https://developer.android.com/reference/android/view/Display#getMetrics(android.util.DisplayMetrics)

To be able to use `getRealMetrics()` we would need to update minSdkVersion to 17 (android 4.2)

https://developer.android.com/reference/android/view/Display#getRealMetrics(android.util.DisplayMetrics)

In Jira ticket there is a updated table with dimensions that were sent previously, values these methods return and with results of calculations.

As discussed with Roland, we need to include dimensions of status bar, so best approach would be to use real dimensions and divide them with screen density. As can be seen in table, values we get this way are similar to those we would get using `context.resources.configuration`, since that method returns available dimensions without status bar or some other screen decoration elements.

### Checklist

- [ ] Updated CHANGELOG.md
