### PR TITLE
AN-1675 Added try-catch blocks on collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Calculations for available screen width and height to now include screen density and be more independent of physical pixel
-- Make collectors more resistant to exceptions
+- Make collectors more resilient to exceptions in event listeners
 
 ## v1.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Calculations for available screen width and height to now include screen density and be more independent of physical pixel
+- Make collectors more resistant to exceptions
 
 ## v1.18.0
 

--- a/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdAdapter.kt
+++ b/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdAdapter.kt
@@ -28,7 +28,7 @@ class BitmovinSdkAdAdapter(val bitmovinPlayer: BitmovinPlayer, val adAnalytics: 
     private val adMapper: AdMapper = AdMapper()
     private val adBreakMapper: AdBreakMapper = AdBreakMapper()
     private val adQuartileFactory: AdQuartileFactory = AdQuartileFactory()
-    private val TAG = "BitmovinADPlayerAdapter"
+    private val TAG = "BitmovinSdkAdAdapter"
 
     private val onAdStartedListener = OnAdStartedListener {
         try {
@@ -118,39 +118,31 @@ class BitmovinSdkAdAdapter(val bitmovinPlayer: BitmovinPlayer, val adAnalytics: 
     }
 
     init {
-        try {
-            bitmovinPlayer.addEventListener(onAdStartedListener)
-            bitmovinPlayer.addEventListener(onAdFinishedListener)
-            bitmovinPlayer.addEventListener(onAdBreakStartedListener)
-            bitmovinPlayer.addEventListener(onAdBreakFinishedListener)
-            bitmovinPlayer.addEventListener(onAdClickedListener)
-            bitmovinPlayer.addEventListener(onAdErrorListener)
-            bitmovinPlayer.addEventListener(onAdSkippedListener)
-            bitmovinPlayer.addEventListener(onAdManifestLoadedListener)
-            bitmovinPlayer.addEventListener(onPlayListener)
-            bitmovinPlayer.addEventListener(onPausedListener)
-            bitmovinPlayer.addEventListener(onAdQuartileListener)
-        } catch (e: Exception) {
-            Log.d(TAG, "On Ad init", e)
-        }
+        bitmovinPlayer.addEventListener(onAdStartedListener)
+        bitmovinPlayer.addEventListener(onAdFinishedListener)
+        bitmovinPlayer.addEventListener(onAdBreakStartedListener)
+        bitmovinPlayer.addEventListener(onAdBreakFinishedListener)
+        bitmovinPlayer.addEventListener(onAdClickedListener)
+        bitmovinPlayer.addEventListener(onAdErrorListener)
+        bitmovinPlayer.addEventListener(onAdSkippedListener)
+        bitmovinPlayer.addEventListener(onAdManifestLoadedListener)
+        bitmovinPlayer.addEventListener(onPlayListener)
+        bitmovinPlayer.addEventListener(onPausedListener)
+        bitmovinPlayer.addEventListener(onAdQuartileListener)
     }
 
     override fun release() {
-        try {
-            bitmovinPlayer.removeEventListener(onAdStartedListener)
-            bitmovinPlayer.removeEventListener(onAdFinishedListener)
-            bitmovinPlayer.removeEventListener(onAdBreakStartedListener)
-            bitmovinPlayer.removeEventListener(onAdBreakFinishedListener)
-            bitmovinPlayer.removeEventListener(onAdClickedListener)
-            bitmovinPlayer.removeEventListener(onAdErrorListener)
-            bitmovinPlayer.removeEventListener(onAdSkippedListener)
-            bitmovinPlayer.removeEventListener(onAdManifestLoadedListener)
-            bitmovinPlayer.removeEventListener(onPlayListener)
-            bitmovinPlayer.removeEventListener(onPausedListener)
-            bitmovinPlayer.removeEventListener(onAdQuartileListener)
-        } catch (e: Exception) {
-            Log.d(TAG, "On Ad release", e)
-        }
+        bitmovinPlayer.removeEventListener(onAdStartedListener)
+        bitmovinPlayer.removeEventListener(onAdFinishedListener)
+        bitmovinPlayer.removeEventListener(onAdBreakStartedListener)
+        bitmovinPlayer.removeEventListener(onAdBreakFinishedListener)
+        bitmovinPlayer.removeEventListener(onAdClickedListener)
+        bitmovinPlayer.removeEventListener(onAdErrorListener)
+        bitmovinPlayer.removeEventListener(onAdSkippedListener)
+        bitmovinPlayer.removeEventListener(onAdManifestLoadedListener)
+        bitmovinPlayer.removeEventListener(onPlayListener)
+        bitmovinPlayer.removeEventListener(onPausedListener)
+        bitmovinPlayer.removeEventListener(onAdQuartileListener)
     }
 
     override val isLinearAdActive: Boolean
@@ -159,12 +151,5 @@ class BitmovinSdkAdAdapter(val bitmovinPlayer: BitmovinPlayer, val adAnalytics: 
         // TODO get actual module from player
         get() = AdModuleInformation("DefaultAdvertisingService", BitmovinUtil.getPlayerVersion())
     override val isAutoplayEnabled: Boolean?
-        get() {
-            return try {
-                bitmovinPlayer.config.playbackConfiguration?.isAutoplayEnabled
-            } catch (e: Exception) {
-                Log.d(TAG, "isAutoplayEnabled", e)
-                null
-            }
-        }
+        get() = bitmovinPlayer.config.playbackConfiguration?.isAutoplayEnabled
 }

--- a/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdAdapter.kt
+++ b/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdAdapter.kt
@@ -1,5 +1,6 @@
 package com.bitmovin.analytics.bitmovin.player
 
+import android.util.Log
 import com.bitmovin.analytics.BitmovinAdAnalytics
 import com.bitmovin.analytics.adapters.AdAdapter
 import com.bitmovin.analytics.bitmovin.player.utils.AdBreakMapper
@@ -27,44 +28,77 @@ class BitmovinSdkAdAdapter(val bitmovinPlayer: BitmovinPlayer, val adAnalytics: 
     private val adMapper: AdMapper = AdMapper()
     private val adBreakMapper: AdBreakMapper = AdBreakMapper()
     private val adQuartileFactory: AdQuartileFactory = AdQuartileFactory()
+    private val TAG = "BitmovinADPlayerAdapter"
 
     private val onAdStartedListener = OnAdStartedListener {
-        val ad = it.ad ?: return@OnAdStartedListener
-        adAnalytics.onAdStarted(adMapper.fromPlayerAd(ad))
+        try {
+            val ad = it.ad ?: return@OnAdStartedListener
+            adAnalytics.onAdStarted(adMapper.fromPlayerAd(ad))
+        } catch (e: Exception) {
+            Log.d(TAG, "On Ad Started", e)
+        }
     }
 
     private val onAdFinishedListener = OnAdFinishedListener {
-        adAnalytics.onAdFinished()
+        try {
+            adAnalytics.onAdFinished()
+        } catch (e: Exception) {
+            Log.d(TAG, "On Ad Finished", e)
+        }
     }
 
     private val onAdBreakStartedListener = OnAdBreakStartedListener {
-        val adBreak = it.adBreak ?: return@OnAdBreakStartedListener
-        adAnalytics.onAdBreakStarted(adBreakMapper.fromPlayerAdConfiguration(adBreak))
+        try {
+            val adBreak = it.adBreak ?: return@OnAdBreakStartedListener
+            adAnalytics.onAdBreakStarted(adBreakMapper.fromPlayerAdConfiguration(adBreak))
+        } catch (e: Exception) {
+            Log.d(TAG, "On Ad Break Started", e)
+        }
     }
 
     private val onAdBreakFinishedListener = OnAdBreakFinishedListener {
-        adAnalytics.onAdBreakFinished()
+        try {
+            adAnalytics.onAdBreakFinished()
+        } catch (e: Exception) {
+            Log.d(TAG, "On Ad Break Finished", e)
+        }
     }
 
     private val onAdClickedListener = OnAdClickedListener {
-        adAnalytics.onAdClicked(it.clickThroughUrl)
+        try {
+            adAnalytics.onAdClicked(it.clickThroughUrl)
+        } catch (e: Exception) {
+            Log.d(TAG, "On Ad Clicked", e)
+        }
     }
 
     private val onAdErrorListener = OnAdErrorListener {
-        val adConf = it.adConfiguration ?: return@OnAdErrorListener
-        adAnalytics.onAdError(
-                adBreakMapper.fromPlayerAdConfiguration(adConf),
-                it.code,
-                it.message)
+        try {
+            val adConf = it.adConfiguration ?: return@OnAdErrorListener
+            adAnalytics.onAdError(
+                    adBreakMapper.fromPlayerAdConfiguration(adConf),
+                    it.code,
+                    it.message)
+        } catch (e: Exception) {
+            Log.d(TAG, "On Ad Error", e)
+        }
     }
 
     private val onAdSkippedListener = OnAdSkippedListener {
-        adAnalytics.onAdSkipped()
+        try {
+            adAnalytics.onAdSkipped()
+        } catch (e: Exception) {
+            Log.d(TAG, "On Ad Skipped", e)
+        }
     }
 
     private val onAdManifestLoadedListener = OnAdManifestLoadedListener {
-        val adBreak = it.adBreak ?: return@OnAdManifestLoadedListener
-        adAnalytics.onAdManifestLoaded(adBreakMapper.fromPlayerAdConfiguration(adBreak), it.downloadTime)
+        try {
+            val adBreak = it.adBreak ?: return@OnAdManifestLoadedListener
+            adAnalytics.onAdManifestLoaded(adBreakMapper.fromPlayerAdConfiguration(adBreak), it.downloadTime)
+        } catch (e: Exception) {
+            Log.d(TAG, "On Ad Manifest Loaded", e)
+        }
     }
 
     private val onPlayListener = OnPlayListener {
@@ -76,35 +110,47 @@ class BitmovinSdkAdAdapter(val bitmovinPlayer: BitmovinPlayer, val adAnalytics: 
     }
 
     private val onAdQuartileListener = OnAdQuartileListener {
-        adAnalytics.onAdQuartile(adQuartileFactory.FromPlayerAdQuartile(it.quartile))
+        try {
+            adAnalytics.onAdQuartile(adQuartileFactory.FromPlayerAdQuartile(it.quartile))
+        } catch (e: Exception) {
+            Log.d(TAG, "On Ad Quartile Listener ", e)
+        }
     }
 
     init {
-        bitmovinPlayer.addEventListener(onAdStartedListener)
-        bitmovinPlayer.addEventListener(onAdFinishedListener)
-        bitmovinPlayer.addEventListener(onAdBreakStartedListener)
-        bitmovinPlayer.addEventListener(onAdBreakFinishedListener)
-        bitmovinPlayer.addEventListener(onAdClickedListener)
-        bitmovinPlayer.addEventListener(onAdErrorListener)
-        bitmovinPlayer.addEventListener(onAdSkippedListener)
-        bitmovinPlayer.addEventListener(onAdManifestLoadedListener)
-        bitmovinPlayer.addEventListener(onPlayListener)
-        bitmovinPlayer.addEventListener(onPausedListener)
-        bitmovinPlayer.addEventListener(onAdQuartileListener)
+        try {
+            bitmovinPlayer.addEventListener(onAdStartedListener)
+            bitmovinPlayer.addEventListener(onAdFinishedListener)
+            bitmovinPlayer.addEventListener(onAdBreakStartedListener)
+            bitmovinPlayer.addEventListener(onAdBreakFinishedListener)
+            bitmovinPlayer.addEventListener(onAdClickedListener)
+            bitmovinPlayer.addEventListener(onAdErrorListener)
+            bitmovinPlayer.addEventListener(onAdSkippedListener)
+            bitmovinPlayer.addEventListener(onAdManifestLoadedListener)
+            bitmovinPlayer.addEventListener(onPlayListener)
+            bitmovinPlayer.addEventListener(onPausedListener)
+            bitmovinPlayer.addEventListener(onAdQuartileListener)
+        } catch (e: Exception) {
+            Log.d(TAG, "On Ad init", e)
+        }
     }
 
     override fun release() {
-        bitmovinPlayer.removeEventListener(onAdStartedListener)
-        bitmovinPlayer.removeEventListener(onAdFinishedListener)
-        bitmovinPlayer.removeEventListener(onAdBreakStartedListener)
-        bitmovinPlayer.removeEventListener(onAdBreakFinishedListener)
-        bitmovinPlayer.removeEventListener(onAdClickedListener)
-        bitmovinPlayer.removeEventListener(onAdErrorListener)
-        bitmovinPlayer.removeEventListener(onAdSkippedListener)
-        bitmovinPlayer.removeEventListener(onAdManifestLoadedListener)
-        bitmovinPlayer.removeEventListener(onPlayListener)
-        bitmovinPlayer.removeEventListener(onPausedListener)
-        bitmovinPlayer.removeEventListener(onAdQuartileListener)
+        try {
+            bitmovinPlayer.removeEventListener(onAdStartedListener)
+            bitmovinPlayer.removeEventListener(onAdFinishedListener)
+            bitmovinPlayer.removeEventListener(onAdBreakStartedListener)
+            bitmovinPlayer.removeEventListener(onAdBreakFinishedListener)
+            bitmovinPlayer.removeEventListener(onAdClickedListener)
+            bitmovinPlayer.removeEventListener(onAdErrorListener)
+            bitmovinPlayer.removeEventListener(onAdSkippedListener)
+            bitmovinPlayer.removeEventListener(onAdManifestLoadedListener)
+            bitmovinPlayer.removeEventListener(onPlayListener)
+            bitmovinPlayer.removeEventListener(onPausedListener)
+            bitmovinPlayer.removeEventListener(onAdQuartileListener)
+        } catch (e: Exception) {
+            Log.d(TAG, "On Ad release", e)
+        }
     }
 
     override val isLinearAdActive: Boolean
@@ -113,5 +159,12 @@ class BitmovinSdkAdAdapter(val bitmovinPlayer: BitmovinPlayer, val adAnalytics: 
         // TODO get actual module from player
         get() = AdModuleInformation("DefaultAdvertisingService", BitmovinUtil.getPlayerVersion())
     override val isAutoplayEnabled: Boolean?
-        get() = bitmovinPlayer.config.playbackConfiguration?.isAutoplayEnabled
+        get() {
+            return try {
+                bitmovinPlayer.config.playbackConfiguration?.isAutoplayEnabled
+            } catch (e: Exception) {
+                Log.d(TAG, "isAutoplayEnabled", e)
+                null
+            }
+        }
 }

--- a/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
+++ b/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
@@ -94,182 +94,163 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     }
 
     private void addPlayerListeners() {
-        try {
-            Log.d(TAG, "Adding Player Listeners");
-            this.bitmovinPlayer.addEventListener(onSourceLoadedListener);
-            this.bitmovinPlayer.addEventListener(onSourceUnloadedListener);
+        Log.d(TAG, "Adding Player Listeners");
+        this.bitmovinPlayer.addEventListener(onSourceLoadedListener);
+        this.bitmovinPlayer.addEventListener(onSourceUnloadedListener);
 
-            this.bitmovinPlayer.addEventListener(onPlayListener);
-            this.bitmovinPlayer.addEventListener(onPlayingListener);
-            this.bitmovinPlayer.addEventListener(onPausedListener);
-            this.bitmovinPlayer.addEventListener(onStallEndedListener);
-            this.bitmovinPlayer.addEventListener(onSeekedListener);
-            this.bitmovinPlayer.addEventListener(onSeekListener);
-            this.bitmovinPlayer.addEventListener(onStallStartedListener);
-            this.bitmovinPlayer.addEventListener(onPlaybackFinishedListener);
-            this.bitmovinPlayer.addEventListener(onReadyListener);
-            this.bitmovinPlayer.addEventListener(onVideoPlaybackQualityChangedListener);
-            this.bitmovinPlayer.addEventListener(onAudioPlaybackQualityChangedListener);
-            this.bitmovinPlayer.addEventListener(onDroppedVideoFramesListener);
-            this.bitmovinPlayer.addEventListener(onSubtitleChangedListener);
-            this.bitmovinPlayer.addEventListener(onAudioChangedListener);
-            this.bitmovinPlayer.addEventListener(onDownloadFinishedListener);
-            this.bitmovinPlayer.addEventListener(onDestroyedListener);
+        this.bitmovinPlayer.addEventListener(onPlayListener);
+        this.bitmovinPlayer.addEventListener(onPlayingListener);
+        this.bitmovinPlayer.addEventListener(onPausedListener);
+        this.bitmovinPlayer.addEventListener(onStallEndedListener);
+        this.bitmovinPlayer.addEventListener(onSeekedListener);
+        this.bitmovinPlayer.addEventListener(onSeekListener);
+        this.bitmovinPlayer.addEventListener(onStallStartedListener);
+        this.bitmovinPlayer.addEventListener(onPlaybackFinishedListener);
+        this.bitmovinPlayer.addEventListener(onReadyListener);
+        this.bitmovinPlayer.addEventListener(onVideoPlaybackQualityChangedListener);
+        this.bitmovinPlayer.addEventListener(onAudioPlaybackQualityChangedListener);
+        this.bitmovinPlayer.addEventListener(onDroppedVideoFramesListener);
+        this.bitmovinPlayer.addEventListener(onSubtitleChangedListener);
+        this.bitmovinPlayer.addEventListener(onAudioChangedListener);
+        this.bitmovinPlayer.addEventListener(onDownloadFinishedListener);
+        this.bitmovinPlayer.addEventListener(onDestroyedListener);
 
-            this.bitmovinPlayer.addEventListener(onErrorListener);
+        this.bitmovinPlayer.addEventListener(onErrorListener);
 
-            this.bitmovinPlayer.addEventListener(onAdBreakStartedListener);
-            this.bitmovinPlayer.addEventListener(onAdBreakFinishedListener);
-        } catch (Exception e) {
-            Log.d(TAG, "On Adding Player Listeners", e);
-        }
+        this.bitmovinPlayer.addEventListener(onAdBreakStartedListener);
+        this.bitmovinPlayer.addEventListener(onAdBreakFinishedListener);
     }
 
     private void removePlayerListener() {
-        try {
-            Log.d(TAG, "Removing Player Listeners");
-            this.bitmovinPlayer.removeEventListener(onSourceLoadedListener);
-            this.bitmovinPlayer.removeEventListener(onSourceUnloadedListener);
+        Log.d(TAG, "Removing Player Listeners");
+        this.bitmovinPlayer.removeEventListener(onSourceLoadedListener);
+        this.bitmovinPlayer.removeEventListener(onSourceUnloadedListener);
 
-            this.bitmovinPlayer.removeEventListener(onPlayListener);
-            this.bitmovinPlayer.removeEventListener(onPlayingListener);
-            this.bitmovinPlayer.removeEventListener(onPausedListener);
-            this.bitmovinPlayer.removeEventListener(onStallEndedListener);
-            this.bitmovinPlayer.removeEventListener(onSeekedListener);
-            this.bitmovinPlayer.removeEventListener(onStallStartedListener);
-            this.bitmovinPlayer.removeEventListener(onSeekListener);
-            this.bitmovinPlayer.removeEventListener(onPlaybackFinishedListener);
-            this.bitmovinPlayer.removeEventListener(onReadyListener);
-            this.bitmovinPlayer.removeEventListener(onVideoPlaybackQualityChangedListener);
-            this.bitmovinPlayer.removeEventListener(onAudioPlaybackQualityChangedListener);
-            this.bitmovinPlayer.removeEventListener(onDroppedVideoFramesListener);
-            this.bitmovinPlayer.removeEventListener(onErrorListener);
-            this.bitmovinPlayer.removeEventListener(onSubtitleChangedListener);
-            this.bitmovinPlayer.removeEventListener(onAudioChangedListener);
-            this.bitmovinPlayer.removeEventListener(onDownloadFinishedListener);
-            this.bitmovinPlayer.removeEventListener(onDestroyedListener);
+        this.bitmovinPlayer.removeEventListener(onPlayListener);
+        this.bitmovinPlayer.removeEventListener(onPlayingListener);
+        this.bitmovinPlayer.removeEventListener(onPausedListener);
+        this.bitmovinPlayer.removeEventListener(onStallEndedListener);
+        this.bitmovinPlayer.removeEventListener(onSeekedListener);
+        this.bitmovinPlayer.removeEventListener(onStallStartedListener);
+        this.bitmovinPlayer.removeEventListener(onSeekListener);
+        this.bitmovinPlayer.removeEventListener(onPlaybackFinishedListener);
+        this.bitmovinPlayer.removeEventListener(onReadyListener);
+        this.bitmovinPlayer.removeEventListener(onVideoPlaybackQualityChangedListener);
+        this.bitmovinPlayer.removeEventListener(onAudioPlaybackQualityChangedListener);
+        this.bitmovinPlayer.removeEventListener(onDroppedVideoFramesListener);
+        this.bitmovinPlayer.removeEventListener(onErrorListener);
+        this.bitmovinPlayer.removeEventListener(onSubtitleChangedListener);
+        this.bitmovinPlayer.removeEventListener(onAudioChangedListener);
+        this.bitmovinPlayer.removeEventListener(onDownloadFinishedListener);
+        this.bitmovinPlayer.removeEventListener(onDestroyedListener);
 
-            this.bitmovinPlayer.removeEventListener(onAdBreakStartedListener);
-            this.bitmovinPlayer.removeEventListener(onAdBreakFinishedListener);
-        }
-        catch (Exception e) {
-            Log.d(TAG, "On Removing Player Listeners", e);
-        }
+        this.bitmovinPlayer.removeEventListener(onAdBreakStartedListener);
+        this.bitmovinPlayer.removeEventListener(onAdBreakFinishedListener);
     }
 
     @Override
     public EventData createEventData() {
-        try {
-            EventData data = factory.build(stateMachine.getImpressionId());
+        EventData data = factory.build(stateMachine.getImpressionId());
 
-            data.setAnalyticsVersion(BuildConfig.VERSION_NAME);
-            data.setPlayer(PlayerType.BITMOVIN.toString());
+        data.setAnalyticsVersion(BuildConfig.VERSION_NAME);
+        data.setPlayer(PlayerType.BITMOVIN.toString());
 
-            //duration
-            double duration = bitmovinPlayer.getDuration();
-            if (duration != Double.POSITIVE_INFINITY) {
-                data.setVideoDuration((long) duration * Util.MILLISECONDS_IN_SECONDS);
-            }
-
-            //ad
-            if (bitmovinPlayer.isAd()) {
-                data.setAd(1);
-            }
-
-            //isLive
-            data.setLive(Util.getIsLiveFromConfigOrPlayer(playerIsReady, config.isLive(), bitmovinPlayer.isLive()));
-
-            //version
-            data.setVersion(PlayerType.BITMOVIN.toString() + "-" + BitmovinUtil.getPlayerVersion());
-
-            //isCasting
-            data.setCasting(bitmovinPlayer.isCasting());
-
-            // DroppedVideoFrames
-            data.setDroppedFrames(this.totalDroppedVideoFrames);
-            this.totalDroppedVideoFrames = 0;
-
-            //streamFormat, mpdUrl, and m3u8Url
-            if (bitmovinPlayer.getConfig() != null && bitmovinPlayer.getConfig().getSourceItem() != null) {
-                SourceItem sourceItem = bitmovinPlayer.getConfig().getSourceItem();
-                switch (sourceItem.getType()) {
-                    case HLS:
-                        if (sourceItem.getHlsSource() != null) {
-                            data.setM3u8Url(sourceItem.getHlsSource().getUrl());
-                        }
-                        data.setStreamFormat(Util.HLS_STREAM_FORMAT);
-                        break;
-                    case DASH:
-                        if (sourceItem.getDashSource() != null) {
-                            data.setMpdUrl(sourceItem.getDashSource().getUrl());
-                        }
-                        data.setStreamFormat(Util.DASH_STREAM_FORMAT);
-                        break;
-                    case PROGRESSIVE:
-                        if (sourceItem.getProgressiveSources() != null && sourceItem.getProgressiveSources().size() > 0) {
-                            data.setM3u8Url(sourceItem.getProgressiveSources().get(0).getUrl());
-                        }
-                        data.setStreamFormat(Util.PROGRESSIVE_STREAM_FORMAT);
-                        break;
-                    case SMOOTH:
-                        data.setStreamFormat(Util.SMOOTH_STREAM_FORMAT);
-                        break;
-                }
-            }
-
-            //video quality
-            VideoQuality videoQuality = bitmovinPlayer.getPlaybackVideoData();
-            if (videoQuality != null) {
-                data.setVideoBitrate(videoQuality.getBitrate());
-                data.setVideoPlaybackHeight(videoQuality.getHeight());
-                data.setVideoPlaybackWidth(videoQuality.getWidth());
-                data.setVideoCodec(videoQuality.getCodec());
-            }
-
-            //audio quality
-            AudioQuality audioQuality = bitmovinPlayer.getPlaybackAudioData();
-            if (audioQuality != null) {
-                data.setAudioBitrate(audioQuality.getBitrate());
-                data.setAudioCodec(audioQuality.getCodec());
-            }
-
-            //Subtitle info
-            SubtitleTrack subtitle = bitmovinPlayer.getSubtitle();
-            if (subtitle != null && subtitle.getId() != null) {
-                data.setSubtitleLanguage(subtitle.getLanguage() != null ? subtitle.getLanguage() : subtitle.getLabel());
-                data.setSubtitleEnabled(true);
-            }
-
-            //Audio language
-            AudioTrack audioTrack = bitmovinPlayer.getAudio();
-            if (audioTrack != null && audioTrack.getId() != null) {
-                data.setAudioLanguage(audioTrack.getLanguage());
-            }
-
-            // DRM Information
-            if (drmInformation != null) {
-                data.setDrmType(drmInformation.getType());
-            }
-
-            return data;
-        } catch (Exception e) {
-            Log.d(TAG, "On Creating Event Data", e);
+        //duration
+        double duration = bitmovinPlayer.getDuration();
+        if (duration != Double.POSITIVE_INFINITY) {
+            data.setVideoDuration((long) duration * Util.MILLISECONDS_IN_SECONDS);
         }
-        return null;
+
+        //ad
+        if (bitmovinPlayer.isAd()) {
+            data.setAd(1);
+        }
+
+        //isLive
+        data.setLive(Util.getIsLiveFromConfigOrPlayer(playerIsReady, config.isLive(), bitmovinPlayer.isLive()));
+
+        //version
+        data.setVersion(PlayerType.BITMOVIN.toString() + "-" + BitmovinUtil.getPlayerVersion());
+
+        //isCasting
+        data.setCasting(bitmovinPlayer.isCasting());
+
+        // DroppedVideoFrames
+        data.setDroppedFrames(this.totalDroppedVideoFrames);
+        this.totalDroppedVideoFrames = 0;
+
+        //streamFormat, mpdUrl, and m3u8Url
+        if (bitmovinPlayer.getConfig() != null && bitmovinPlayer.getConfig().getSourceItem() != null) {
+            SourceItem sourceItem = bitmovinPlayer.getConfig().getSourceItem();
+            switch (sourceItem.getType()) {
+                case HLS:
+                    if (sourceItem.getHlsSource() != null) {
+                        data.setM3u8Url(sourceItem.getHlsSource().getUrl());
+                    }
+                    data.setStreamFormat(Util.HLS_STREAM_FORMAT);
+                    break;
+                case DASH:
+                    if (sourceItem.getDashSource() != null) {
+                        data.setMpdUrl(sourceItem.getDashSource().getUrl());
+                    }
+                    data.setStreamFormat(Util.DASH_STREAM_FORMAT);
+                    break;
+                case PROGRESSIVE:
+                    if (sourceItem.getProgressiveSources() != null && sourceItem.getProgressiveSources().size() > 0) {
+                        data.setM3u8Url(sourceItem.getProgressiveSources().get(0).getUrl());
+                    }
+                    data.setStreamFormat(Util.PROGRESSIVE_STREAM_FORMAT);
+                    break;
+                case SMOOTH:
+                    data.setStreamFormat(Util.SMOOTH_STREAM_FORMAT);
+                    break;
+            }
+        }
+
+        //video quality
+        VideoQuality videoQuality = bitmovinPlayer.getPlaybackVideoData();
+        if (videoQuality != null) {
+            data.setVideoBitrate(videoQuality.getBitrate());
+            data.setVideoPlaybackHeight(videoQuality.getHeight());
+            data.setVideoPlaybackWidth(videoQuality.getWidth());
+            data.setVideoCodec(videoQuality.getCodec());
+        }
+
+        //audio quality
+        AudioQuality audioQuality = bitmovinPlayer.getPlaybackAudioData();
+        if (audioQuality != null) {
+            data.setAudioBitrate(audioQuality.getBitrate());
+            data.setAudioCodec(audioQuality.getCodec());
+        }
+
+        //Subtitle info
+        SubtitleTrack subtitle = bitmovinPlayer.getSubtitle();
+        if (subtitle != null && subtitle.getId() != null) {
+            data.setSubtitleLanguage(subtitle.getLanguage() != null ? subtitle.getLanguage() : subtitle.getLabel());
+            data.setSubtitleEnabled(true);
+        }
+
+        //Audio language
+        AudioTrack audioTrack = bitmovinPlayer.getAudio();
+        if (audioTrack != null && audioTrack.getId() != null) {
+            data.setAudioLanguage(audioTrack.getLanguage());
+        }
+
+        // DRM Information
+        if (drmInformation != null) {
+            data.setDrmType(drmInformation.getType());
+        }
+
+        return data;
     }
 
     @Override
     public void release() {
-        try {
-            playerIsReady = false;
-            if (bitmovinPlayer != null) {
-                removePlayerListener();
-            }
-            stateMachine.resetStateMachine();
-        } catch (Exception e) {
-            Log.d(TAG, "Release", e);
+        playerIsReady = false;
+        if (bitmovinPlayer != null) {
+            removePlayerListener();
         }
-
+        stateMachine.resetStateMachine();
     }
 
     @Override
@@ -293,27 +274,20 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
       so in case the player starts a video due to autoplay=true we need to transition into startup state manually
      */
     private void checkAutoplayStartup() {
-        try {
+        if (bitmovinPlayer.getConfig() != null) {
             PlaybackConfiguration playbackConfiguration = bitmovinPlayer.getConfig().getPlaybackConfiguration();
             SourceConfiguration source = bitmovinPlayer.getConfig().getSourceConfiguration();
             if (playbackConfiguration != null && source != null && source.getFirstSourceItem() != null && playbackConfiguration.isAutoplayEnabled()) {
                 startup();
             }
-        } catch (Exception e) {
-            Log.d(TAG, "On Check Autoplay Startup", e);
         }
     }
 
     private void startup() {
-        try {
-            stateMachine.transitionState(PlayerState.STARTUP, getPosition());
-            if (!bitmovinPlayer.isAd()) {
-                isVideoAttemptedPlay = true;
-            }
-        } catch (Exception e) {
-            Log.d(TAG, "On Startup", e);
+        stateMachine.transitionState(PlayerState.STARTUP, getPosition());
+        if (!bitmovinPlayer.isAd()) {
+            isVideoAttemptedPlay = true;
         }
-
     }
 
     /**
@@ -346,8 +320,8 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
             try{
                 Log.d(TAG, "On Destroy");
                 if (!stateMachine.isStartupFinished() && isVideoAttemptedPlay) {
-                    stateMachine.setVideoStartFailedReason(VideoStartFailedReason.PAGE_CLOSED);
-                    stateMachine.transitionState(PlayerState.EXITBEFOREVIDEOSTART, getPosition());
+                      stateMachine.setVideoStartFailedReason(VideoStartFailedReason.PAGE_CLOSED);
+                      stateMachine.transitionState(PlayerState.EXITBEFOREVIDEOSTART, getPosition());
                 }
             } catch (Exception e) {
                 Log.d(TAG, "On Destroyed", e);

--- a/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
+++ b/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
@@ -94,163 +94,182 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     }
 
     private void addPlayerListeners() {
-        Log.d(TAG, "Adding Player Listeners");
-        this.bitmovinPlayer.addEventListener(onSourceLoadedListener);
-        this.bitmovinPlayer.addEventListener(onSourceUnloadedListener);
+        try {
+            Log.d(TAG, "Adding Player Listeners");
+            this.bitmovinPlayer.addEventListener(onSourceLoadedListener);
+            this.bitmovinPlayer.addEventListener(onSourceUnloadedListener);
 
-        this.bitmovinPlayer.addEventListener(onPlayListener);
-        this.bitmovinPlayer.addEventListener(onPlayingListener);
-        this.bitmovinPlayer.addEventListener(onPausedListener);
-        this.bitmovinPlayer.addEventListener(onStallEndedListener);
-        this.bitmovinPlayer.addEventListener(onSeekedListener);
-        this.bitmovinPlayer.addEventListener(onSeekListener);
-        this.bitmovinPlayer.addEventListener(onStallStartedListener);
-        this.bitmovinPlayer.addEventListener(onPlaybackFinishedListener);
-        this.bitmovinPlayer.addEventListener(onReadyListener);
-        this.bitmovinPlayer.addEventListener(onVideoPlaybackQualityChangedListener);
-        this.bitmovinPlayer.addEventListener(onAudioPlaybackQualityChangedListener);
-        this.bitmovinPlayer.addEventListener(onDroppedVideoFramesListener);
-        this.bitmovinPlayer.addEventListener(onSubtitleChangedListener);
-        this.bitmovinPlayer.addEventListener(onAudioChangedListener);
-        this.bitmovinPlayer.addEventListener(onDownloadFinishedListener);
-        this.bitmovinPlayer.addEventListener(onDestroyedListener);
+            this.bitmovinPlayer.addEventListener(onPlayListener);
+            this.bitmovinPlayer.addEventListener(onPlayingListener);
+            this.bitmovinPlayer.addEventListener(onPausedListener);
+            this.bitmovinPlayer.addEventListener(onStallEndedListener);
+            this.bitmovinPlayer.addEventListener(onSeekedListener);
+            this.bitmovinPlayer.addEventListener(onSeekListener);
+            this.bitmovinPlayer.addEventListener(onStallStartedListener);
+            this.bitmovinPlayer.addEventListener(onPlaybackFinishedListener);
+            this.bitmovinPlayer.addEventListener(onReadyListener);
+            this.bitmovinPlayer.addEventListener(onVideoPlaybackQualityChangedListener);
+            this.bitmovinPlayer.addEventListener(onAudioPlaybackQualityChangedListener);
+            this.bitmovinPlayer.addEventListener(onDroppedVideoFramesListener);
+            this.bitmovinPlayer.addEventListener(onSubtitleChangedListener);
+            this.bitmovinPlayer.addEventListener(onAudioChangedListener);
+            this.bitmovinPlayer.addEventListener(onDownloadFinishedListener);
+            this.bitmovinPlayer.addEventListener(onDestroyedListener);
 
-        this.bitmovinPlayer.addEventListener(onErrorListener);
+            this.bitmovinPlayer.addEventListener(onErrorListener);
 
-        this.bitmovinPlayer.addEventListener(onAdBreakStartedListener);
-        this.bitmovinPlayer.addEventListener(onAdBreakFinishedListener);
+            this.bitmovinPlayer.addEventListener(onAdBreakStartedListener);
+            this.bitmovinPlayer.addEventListener(onAdBreakFinishedListener);
+        } catch (Exception e) {
+            Log.d(TAG, "On Adding Player Listeners", e);
+        }
     }
 
     private void removePlayerListener() {
-        Log.d(TAG, "Removing Player Listeners");
-        this.bitmovinPlayer.removeEventListener(onSourceLoadedListener);
-        this.bitmovinPlayer.removeEventListener(onSourceUnloadedListener);
+        try {
+            Log.d(TAG, "Removing Player Listeners");
+            this.bitmovinPlayer.removeEventListener(onSourceLoadedListener);
+            this.bitmovinPlayer.removeEventListener(onSourceUnloadedListener);
 
-        this.bitmovinPlayer.removeEventListener(onPlayListener);
-        this.bitmovinPlayer.removeEventListener(onPlayingListener);
-        this.bitmovinPlayer.removeEventListener(onPausedListener);
-        this.bitmovinPlayer.removeEventListener(onStallEndedListener);
-        this.bitmovinPlayer.removeEventListener(onSeekedListener);
-        this.bitmovinPlayer.removeEventListener(onStallStartedListener);
-        this.bitmovinPlayer.removeEventListener(onSeekListener);
-        this.bitmovinPlayer.removeEventListener(onPlaybackFinishedListener);
-        this.bitmovinPlayer.removeEventListener(onReadyListener);
-        this.bitmovinPlayer.removeEventListener(onVideoPlaybackQualityChangedListener);
-        this.bitmovinPlayer.removeEventListener(onAudioPlaybackQualityChangedListener);
-        this.bitmovinPlayer.removeEventListener(onDroppedVideoFramesListener);
-        this.bitmovinPlayer.removeEventListener(onErrorListener);
-        this.bitmovinPlayer.removeEventListener(onSubtitleChangedListener);
-        this.bitmovinPlayer.removeEventListener(onAudioChangedListener);
-        this.bitmovinPlayer.removeEventListener(onDownloadFinishedListener);
-        this.bitmovinPlayer.removeEventListener(onDestroyedListener);
+            this.bitmovinPlayer.removeEventListener(onPlayListener);
+            this.bitmovinPlayer.removeEventListener(onPlayingListener);
+            this.bitmovinPlayer.removeEventListener(onPausedListener);
+            this.bitmovinPlayer.removeEventListener(onStallEndedListener);
+            this.bitmovinPlayer.removeEventListener(onSeekedListener);
+            this.bitmovinPlayer.removeEventListener(onStallStartedListener);
+            this.bitmovinPlayer.removeEventListener(onSeekListener);
+            this.bitmovinPlayer.removeEventListener(onPlaybackFinishedListener);
+            this.bitmovinPlayer.removeEventListener(onReadyListener);
+            this.bitmovinPlayer.removeEventListener(onVideoPlaybackQualityChangedListener);
+            this.bitmovinPlayer.removeEventListener(onAudioPlaybackQualityChangedListener);
+            this.bitmovinPlayer.removeEventListener(onDroppedVideoFramesListener);
+            this.bitmovinPlayer.removeEventListener(onErrorListener);
+            this.bitmovinPlayer.removeEventListener(onSubtitleChangedListener);
+            this.bitmovinPlayer.removeEventListener(onAudioChangedListener);
+            this.bitmovinPlayer.removeEventListener(onDownloadFinishedListener);
+            this.bitmovinPlayer.removeEventListener(onDestroyedListener);
 
-        this.bitmovinPlayer.removeEventListener(onAdBreakStartedListener);
-        this.bitmovinPlayer.removeEventListener(onAdBreakFinishedListener);
+            this.bitmovinPlayer.removeEventListener(onAdBreakStartedListener);
+            this.bitmovinPlayer.removeEventListener(onAdBreakFinishedListener);
+        }
+        catch (Exception e) {
+            Log.d(TAG, "On Removing Player Listeners", e);
+        }
     }
 
     @Override
     public EventData createEventData() {
-        EventData data = factory.build(stateMachine.getImpressionId());
+        try {
+            EventData data = factory.build(stateMachine.getImpressionId());
 
-        data.setAnalyticsVersion(BuildConfig.VERSION_NAME);
-        data.setPlayer(PlayerType.BITMOVIN.toString());
+            data.setAnalyticsVersion(BuildConfig.VERSION_NAME);
+            data.setPlayer(PlayerType.BITMOVIN.toString());
 
-        //duration
-        double duration = bitmovinPlayer.getDuration();
-        if (duration != Double.POSITIVE_INFINITY) {
-            data.setVideoDuration((long) duration * Util.MILLISECONDS_IN_SECONDS);
-        }
-
-        //ad
-        if (bitmovinPlayer.isAd()) {
-            data.setAd(1);
-        }
-
-        //isLive
-        data.setLive(Util.getIsLiveFromConfigOrPlayer(playerIsReady, config.isLive(), bitmovinPlayer.isLive()));
-
-        //version
-        data.setVersion(PlayerType.BITMOVIN.toString() + "-" + BitmovinUtil.getPlayerVersion());
-
-        //isCasting
-        data.setCasting(bitmovinPlayer.isCasting());
-
-        // DroppedVideoFrames
-        data.setDroppedFrames(this.totalDroppedVideoFrames);
-        this.totalDroppedVideoFrames = 0;
-
-        //streamFormat, mpdUrl, and m3u8Url
-        if (bitmovinPlayer.getConfig() != null && bitmovinPlayer.getConfig().getSourceItem() != null) {
-            SourceItem sourceItem = bitmovinPlayer.getConfig().getSourceItem();
-            switch (sourceItem.getType()) {
-                case HLS:
-                    if (sourceItem.getHlsSource() != null) {
-                        data.setM3u8Url(sourceItem.getHlsSource().getUrl());
-                    }
-                    data.setStreamFormat(Util.HLS_STREAM_FORMAT);
-                    break;
-                case DASH:
-                    if (sourceItem.getDashSource() != null) {
-                        data.setMpdUrl(sourceItem.getDashSource().getUrl());
-                    }
-                    data.setStreamFormat(Util.DASH_STREAM_FORMAT);
-                    break;
-                case PROGRESSIVE:
-                    if (sourceItem.getProgressiveSources() != null && sourceItem.getProgressiveSources().size() > 0) {
-                        data.setM3u8Url(sourceItem.getProgressiveSources().get(0).getUrl());
-                    }
-                    data.setStreamFormat(Util.PROGRESSIVE_STREAM_FORMAT);
-                    break;
-                case SMOOTH:
-                    data.setStreamFormat(Util.SMOOTH_STREAM_FORMAT);
-                    break;
+            //duration
+            double duration = bitmovinPlayer.getDuration();
+            if (duration != Double.POSITIVE_INFINITY) {
+                data.setVideoDuration((long) duration * Util.MILLISECONDS_IN_SECONDS);
             }
-        }
 
-        //video quality
-        VideoQuality videoQuality = bitmovinPlayer.getPlaybackVideoData();
-        if (videoQuality != null) {
-            data.setVideoBitrate(videoQuality.getBitrate());
-            data.setVideoPlaybackHeight(videoQuality.getHeight());
-            data.setVideoPlaybackWidth(videoQuality.getWidth());
-            data.setVideoCodec(videoQuality.getCodec());
-        }
+            //ad
+            if (bitmovinPlayer.isAd()) {
+                data.setAd(1);
+            }
 
-        //audio quality
-        AudioQuality audioQuality = bitmovinPlayer.getPlaybackAudioData();
-        if (audioQuality != null) {
-            data.setAudioBitrate(audioQuality.getBitrate());
-            data.setAudioCodec(audioQuality.getCodec());
-        }
+            //isLive
+            data.setLive(Util.getIsLiveFromConfigOrPlayer(playerIsReady, config.isLive(), bitmovinPlayer.isLive()));
 
-        //Subtitle info
-        SubtitleTrack subtitle = bitmovinPlayer.getSubtitle();
-        if (subtitle != null && subtitle.getId() != null) {
-            data.setSubtitleLanguage(subtitle.getLanguage() != null ? subtitle.getLanguage() : subtitle.getLabel());
-            data.setSubtitleEnabled(true);
-        }
+            //version
+            data.setVersion(PlayerType.BITMOVIN.toString() + "-" + BitmovinUtil.getPlayerVersion());
 
-        //Audio language
-        AudioTrack audioTrack = bitmovinPlayer.getAudio();
-        if (audioTrack != null && audioTrack.getId() != null) {
-            data.setAudioLanguage(audioTrack.getLanguage());
-        }
+            //isCasting
+            data.setCasting(bitmovinPlayer.isCasting());
 
-        // DRM Information
-        if (drmInformation != null) {
-            data.setDrmType(drmInformation.getType());
-        }
+            // DroppedVideoFrames
+            data.setDroppedFrames(this.totalDroppedVideoFrames);
+            this.totalDroppedVideoFrames = 0;
 
-        return data;
+            //streamFormat, mpdUrl, and m3u8Url
+            if (bitmovinPlayer.getConfig() != null && bitmovinPlayer.getConfig().getSourceItem() != null) {
+                SourceItem sourceItem = bitmovinPlayer.getConfig().getSourceItem();
+                switch (sourceItem.getType()) {
+                    case HLS:
+                        if (sourceItem.getHlsSource() != null) {
+                            data.setM3u8Url(sourceItem.getHlsSource().getUrl());
+                        }
+                        data.setStreamFormat(Util.HLS_STREAM_FORMAT);
+                        break;
+                    case DASH:
+                        if (sourceItem.getDashSource() != null) {
+                            data.setMpdUrl(sourceItem.getDashSource().getUrl());
+                        }
+                        data.setStreamFormat(Util.DASH_STREAM_FORMAT);
+                        break;
+                    case PROGRESSIVE:
+                        if (sourceItem.getProgressiveSources() != null && sourceItem.getProgressiveSources().size() > 0) {
+                            data.setM3u8Url(sourceItem.getProgressiveSources().get(0).getUrl());
+                        }
+                        data.setStreamFormat(Util.PROGRESSIVE_STREAM_FORMAT);
+                        break;
+                    case SMOOTH:
+                        data.setStreamFormat(Util.SMOOTH_STREAM_FORMAT);
+                        break;
+                }
+            }
+
+            //video quality
+            VideoQuality videoQuality = bitmovinPlayer.getPlaybackVideoData();
+            if (videoQuality != null) {
+                data.setVideoBitrate(videoQuality.getBitrate());
+                data.setVideoPlaybackHeight(videoQuality.getHeight());
+                data.setVideoPlaybackWidth(videoQuality.getWidth());
+                data.setVideoCodec(videoQuality.getCodec());
+            }
+
+            //audio quality
+            AudioQuality audioQuality = bitmovinPlayer.getPlaybackAudioData();
+            if (audioQuality != null) {
+                data.setAudioBitrate(audioQuality.getBitrate());
+                data.setAudioCodec(audioQuality.getCodec());
+            }
+
+            //Subtitle info
+            SubtitleTrack subtitle = bitmovinPlayer.getSubtitle();
+            if (subtitle != null && subtitle.getId() != null) {
+                data.setSubtitleLanguage(subtitle.getLanguage() != null ? subtitle.getLanguage() : subtitle.getLabel());
+                data.setSubtitleEnabled(true);
+            }
+
+            //Audio language
+            AudioTrack audioTrack = bitmovinPlayer.getAudio();
+            if (audioTrack != null && audioTrack.getId() != null) {
+                data.setAudioLanguage(audioTrack.getLanguage());
+            }
+
+            // DRM Information
+            if (drmInformation != null) {
+                data.setDrmType(drmInformation.getType());
+            }
+
+            return data;
+        } catch (Exception e) {
+            Log.d(TAG, "On Creating Event Data", e);
+        }
+        return null;
     }
 
     @Override
     public void release() {
-        playerIsReady = false;
-        if (bitmovinPlayer != null) {
-            removePlayerListener();
+        try {
+            playerIsReady = false;
+            if (bitmovinPlayer != null) {
+                removePlayerListener();
+            }
+            stateMachine.resetStateMachine();
+        } catch (Exception e) {
+            Log.d(TAG, "Release", e);
         }
-        stateMachine.resetStateMachine();
+
     }
 
     @Override
@@ -274,18 +293,27 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
       so in case the player starts a video due to autoplay=true we need to transition into startup state manually
      */
     private void checkAutoplayStartup() {
-        PlaybackConfiguration playbackConfiguration = bitmovinPlayer.getConfig().getPlaybackConfiguration();
-        SourceConfiguration source = bitmovinPlayer.getConfig().getSourceConfiguration();
-        if (playbackConfiguration != null && source != null && source.getFirstSourceItem() != null && playbackConfiguration.isAutoplayEnabled()) {
-            startup();
+        try {
+            PlaybackConfiguration playbackConfiguration = bitmovinPlayer.getConfig().getPlaybackConfiguration();
+            SourceConfiguration source = bitmovinPlayer.getConfig().getSourceConfiguration();
+            if (playbackConfiguration != null && source != null && source.getFirstSourceItem() != null && playbackConfiguration.isAutoplayEnabled()) {
+                startup();
+            }
+        } catch (Exception e) {
+            Log.d(TAG, "On Check Autoplay Startup", e);
         }
     }
 
     private void startup() {
-        stateMachine.transitionState(PlayerState.STARTUP, getPosition());
-        if (!bitmovinPlayer.isAd()) {
-            isVideoAttemptedPlay = true;
+        try {
+            stateMachine.transitionState(PlayerState.STARTUP, getPosition());
+            if (!bitmovinPlayer.isAd()) {
+                isVideoAttemptedPlay = true;
+            }
+        } catch (Exception e) {
+            Log.d(TAG, "On Startup", e);
         }
+
     }
 
     /**
@@ -303,18 +331,26 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnSourceUnloadedListener onSourceUnloadedListener = new OnSourceUnloadedListener() {
         @Override
         public void onSourceUnloaded(SourceUnloadedEvent sourceUnloadedEvent) {
-            Log.d(TAG, "On Source Unloaded");
-            stateMachine.resetStateMachine();
+            try {
+                Log.d(TAG, "On Source Unloaded");
+                stateMachine.resetStateMachine();
+            } catch (Exception e) {
+                Log.d(TAG, "On Source Unloaded", e);
+            }
         }
     };
 
     private OnDestroyListener onDestroyedListener = new OnDestroyListener() {
         @Override
         public void onDestroy(DestroyEvent destroyEvent) {
-            Log.d(TAG, "On Destroy");
-            if (!stateMachine.isStartupFinished() && isVideoAttemptedPlay) {
-                stateMachine.setVideoStartFailedReason(VideoStartFailedReason.PAGE_CLOSED);
-                stateMachine.transitionState(PlayerState.EXITBEFOREVIDEOSTART, getPosition());
+            try{
+                Log.d(TAG, "On Destroy");
+                if (!stateMachine.isStartupFinished() && isVideoAttemptedPlay) {
+                    stateMachine.setVideoStartFailedReason(VideoStartFailedReason.PAGE_CLOSED);
+                    stateMachine.transitionState(PlayerState.EXITBEFOREVIDEOSTART, getPosition());
+                }
+            } catch (Exception e) {
+                Log.d(TAG, "On Destroyed", e);
             }
         }
     };
@@ -322,11 +358,15 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnPlaybackFinishedListener onPlaybackFinishedListener = new OnPlaybackFinishedListener() {
         @Override
         public void onPlaybackFinished(PlaybackFinishedEvent playbackFinishedEvent) {
-            Log.d(TAG, "On Playback Finished Listener");
+            try {
+                Log.d(TAG, "On Playback Finished Listener");
 
-            long position = (bitmovinPlayer.getDuration() != Double.POSITIVE_INFINITY) ? (long) bitmovinPlayer.getDuration() * Util.MILLISECONDS_IN_SECONDS : getPosition();
-            stateMachine.transitionState(PlayerState.PAUSE, position);
-            stateMachine.disableHeartbeat();
+                long position = (bitmovinPlayer.getDuration() != Double.POSITIVE_INFINITY) ? (long) bitmovinPlayer.getDuration() * Util.MILLISECONDS_IN_SECONDS : getPosition();
+                stateMachine.transitionState(PlayerState.PAUSE, position);
+                stateMachine.disableHeartbeat();
+            } catch (Exception e) {
+                Log.d(TAG, "On Playback Finished", e);
+            }
 
         }
     };
@@ -342,17 +382,25 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnPausedListener onPausedListener = new OnPausedListener() {
         @Override
         public void onPaused(PausedEvent pausedEvent) {
-            Log.d(TAG, "On Pause Listener");
-            stateMachine.pause(getPosition());
+            try {
+                Log.d(TAG, "On Pause Listener");
+                stateMachine.pause(getPosition());
+            } catch (Exception e) {
+                Log.d(TAG, "On Pause", e);
+            }
         }
     };
 
     private OnPlayListener onPlayListener = new OnPlayListener() {
         @Override
         public void onPlay(PlayEvent playEvent) {
-            Log.d(TAG, "On Play Listener");
-            if (!stateMachine.isStartupFinished()) {
-                startup();
+            try {
+                Log.d(TAG, "On Play Listener");
+                if (!stateMachine.isStartupFinished()) {
+                    startup();
+                }
+            } catch (Exception e) {
+                Log.d(TAG, "On Play", e);
             }
         }
     };
@@ -360,8 +408,12 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnPlayingListener onPlayingListener = new OnPlayingListener() {
         @Override
         public void onPlaying(PlayingEvent playingEvent) {
-            Log.d(TAG, "On Playing Listener " + stateMachine.getCurrentState().toString());
-            stateMachine.transitionState(PlayerState.PLAYING, getPosition());
+            try {
+                Log.d(TAG, "On Playing Listener " + stateMachine.getCurrentState().toString());
+                stateMachine.transitionState(PlayerState.PLAYING, getPosition());
+            } catch (Exception e) {
+                Log.d(TAG, "On Playing", e);
+            }
         }
     };
 
@@ -375,9 +427,13 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnSeekListener onSeekListener = new OnSeekListener() {
         @Override
         public void onSeek(SeekEvent seekEvent) {
-            Log.d(TAG, "On Seek Listener");
-            if (stateMachine.getCurrentState() != PlayerState.SEEKING && stateMachine.isStartupFinished()) {
-                stateMachine.transitionState(PlayerState.SEEKING, getPosition());
+            try {
+                Log.d(TAG, "On Seek Listener");
+                if (stateMachine.getCurrentState() != PlayerState.SEEKING && stateMachine.isStartupFinished()) {
+                    stateMachine.transitionState(PlayerState.SEEKING, getPosition());
+                }
+            } catch (Exception e) {
+                Log.d(TAG, "On Seek", e);
             }
         }
     };
@@ -385,13 +441,17 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnStallEndedListener onStallEndedListener = new OnStallEndedListener() {
         @Override
         public void onStallEnded(StallEndedEvent stallEndedEvent) {
-            Log.d(TAG, "On Stall Ended: " + String.valueOf(bitmovinPlayer.isPlaying()));
-            if (stateMachine.isStartupFinished()) {
-                if (bitmovinPlayer.isPlaying() && stateMachine.getCurrentState() != PlayerState.PLAYING) {
-                    stateMachine.transitionState(PlayerState.PLAYING, getPosition());
-                } else if (bitmovinPlayer.isPaused() && stateMachine.getCurrentState() != PlayerState.PAUSE) {
-                    stateMachine.transitionState(PlayerState.PAUSE, getPosition());
+            try {
+                Log.d(TAG, "On Stall Ended: " + String.valueOf(bitmovinPlayer.isPlaying()));
+                if (stateMachine.isStartupFinished()) {
+                    if (bitmovinPlayer.isPlaying() && stateMachine.getCurrentState() != PlayerState.PLAYING) {
+                        stateMachine.transitionState(PlayerState.PLAYING, getPosition());
+                    } else if (bitmovinPlayer.isPaused() && stateMachine.getCurrentState() != PlayerState.PAUSE) {
+                        stateMachine.transitionState(PlayerState.PAUSE, getPosition());
+                    }
                 }
+            } catch (Exception e) {
+                Log.d(TAG, "On Stall Ended", e);
             }
         }
     };
@@ -399,11 +459,15 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnAudioChangedListener onAudioChangedListener = new OnAudioChangedListener() {
         @Override
         public void onAudioChanged(AudioChangedEvent audioChangedEvent) {
-            Log.d(TAG, "On AudioChanged: " + bitmovinPlayer.getAudio().getId());
-            if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.isStartupFinished()) {
-                PlayerState originalState = stateMachine.getCurrentState();
-                stateMachine.transitionState(PlayerState.AUDIOTRACKCHANGE, getPosition());
-                stateMachine.transitionState(originalState, getPosition());
+            try{
+                Log.d(TAG, "On AudioChanged: " + bitmovinPlayer.getAudio().getId());
+                if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.isStartupFinished()) {
+                    PlayerState originalState = stateMachine.getCurrentState();
+                    stateMachine.transitionState(PlayerState.AUDIOTRACKCHANGE, getPosition());
+                    stateMachine.transitionState(originalState, getPosition());
+                }
+            } catch (Exception e) {
+                Log.d(TAG, "On Audio Changed", e);
             }
         }
     };
@@ -411,11 +475,15 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnSubtitleChangedListener onSubtitleChangedListener = new OnSubtitleChangedListener() {
         @Override
         public void onSubtitleChanged(SubtitleChangedEvent event) {
-            Log.d(TAG, "On SubtitleChanged: " + bitmovinPlayer.getSubtitle().getId());
-            if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.isStartupFinished()) {
-                PlayerState originalState = stateMachine.getCurrentState();
-                stateMachine.transitionState(PlayerState.SUBTITLECHANGE, getPosition());
-                stateMachine.transitionState(originalState, getPosition());
+            try{
+                Log.d(TAG, "On SubtitleChanged: " + bitmovinPlayer.getSubtitle().getId());
+                if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.isStartupFinished()) {
+                    PlayerState originalState = stateMachine.getCurrentState();
+                    stateMachine.transitionState(PlayerState.SUBTITLECHANGE, getPosition());
+                    stateMachine.transitionState(originalState, getPosition());
+                }
+            } catch (Exception e) {
+                Log.d(TAG, "On Subtitle Changed", e);
             }
         }
     };
@@ -423,9 +491,13 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnStallStartedListener onStallStartedListener = new OnStallStartedListener() {
         @Override
         public void onStallStarted(StallStartedEvent stallStartedEvent) {
-            Log.d(TAG, "On Stall Started Listener");
-            if (stateMachine.getCurrentState() != PlayerState.SEEKING && stateMachine.isStartupFinished()) {
-                stateMachine.transitionState(PlayerState.BUFFERING, getPosition());
+            try {
+                Log.d(TAG, "On Stall Started Listener");
+                if (stateMachine.getCurrentState() != PlayerState.SEEKING && stateMachine.isStartupFinished()) {
+                    stateMachine.transitionState(PlayerState.BUFFERING, getPosition());
+                }
+            } catch (Exception e) {
+                Log.d(TAG, "On Stall Started", e);
             }
         }
     };
@@ -434,12 +506,16 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         @Override
         public void onVideoPlaybackQualityChanged(
                 VideoPlaybackQualityChangedEvent videoPlaybackQualityChangedEvent) {
-            Log.d(TAG, "On Video Quality Changed");
-            if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE)
-                    && stateMachine.isStartupFinished() && stateMachine.isQualityChangeEventEnabled()) {
-                PlayerState originalState = stateMachine.getCurrentState();
-                stateMachine.transitionState(PlayerState.QUALITYCHANGE, getPosition());
-                stateMachine.transitionState(originalState, getPosition());
+            try {
+                Log.d(TAG, "On Video Quality Changed");
+                if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE)
+                        && stateMachine.isStartupFinished() && stateMachine.isQualityChangeEventEnabled()) {
+                    PlayerState originalState = stateMachine.getCurrentState();
+                    stateMachine.transitionState(PlayerState.QUALITYCHANGE, getPosition());
+                    stateMachine.transitionState(originalState, getPosition());
+                }
+            } catch (Exception e) {
+                Log.d(TAG, "On Video Playback Quality Changed", e);
             }
         }
     };
@@ -447,7 +523,11 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnDroppedVideoFramesListener onDroppedVideoFramesListener = new OnDroppedVideoFramesListener() {
         @Override
         public void onDroppedVideoFrames(DroppedVideoFramesEvent droppedVideoFramesEvent) {
-            totalDroppedVideoFrames += droppedVideoFramesEvent.getDroppedFrames();
+            try {
+                totalDroppedVideoFrames += droppedVideoFramesEvent.getDroppedFrames();
+            } catch (Exception e) {
+                Log.d(TAG, "On Dropped Video Frames", e);
+            }
         }
     };
 
@@ -455,17 +535,21 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         @Override
         public void onAudioPlaybackQualityChanged(
                 AudioPlaybackQualityChangedEvent audioPlaybackQualityChangedEvent) {
-            Log.d(TAG, "On Audio Quality Changed");
-            if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE)
-                    && stateMachine.isStartupFinished() && stateMachine.isQualityChangeEventEnabled()) {
-                PlayerState originalState = stateMachine.getCurrentState();
-                AudioQuality oldQuality = audioPlaybackQualityChangedEvent.getOldAudioQuality();
-                AudioQuality newQuality = audioPlaybackQualityChangedEvent.getNewAudioQuality();
-                if (oldQuality != null && newQuality != null && oldQuality.getBitrate() == newQuality.getBitrate()) {
-                    return;
+            try {
+                Log.d(TAG, "On Audio Quality Changed");
+                if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE)
+                        && stateMachine.isStartupFinished() && stateMachine.isQualityChangeEventEnabled()) {
+                    PlayerState originalState = stateMachine.getCurrentState();
+                    AudioQuality oldQuality = audioPlaybackQualityChangedEvent.getOldAudioQuality();
+                    AudioQuality newQuality = audioPlaybackQualityChangedEvent.getNewAudioQuality();
+                    if (oldQuality != null && newQuality != null && oldQuality.getBitrate() == newQuality.getBitrate()) {
+                        return;
+                    }
+                    stateMachine.transitionState(PlayerState.QUALITYCHANGE, getPosition());
+                    stateMachine.transitionState(originalState, getPosition());
                 }
-                stateMachine.transitionState(PlayerState.QUALITYCHANGE, getPosition());
-                stateMachine.transitionState(originalState, getPosition());
+            } catch (Exception e) {
+                Log.d(TAG, "On Audio Quality Changed", e);
             }
         }
     };
@@ -473,9 +557,13 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnDownloadFinishedListener onDownloadFinishedListener = new OnDownloadFinishedListener() {
         @Override
         public void onDownloadFinished(DownloadFinishedEvent downloadFinishedEvent) {
-            if (downloadFinishedEvent.getDownloadType().toString().contains("drm/license")) {
-                drmInformation = new DRMInformation(Double.valueOf(downloadFinishedEvent.getDownloadTime() * 1000).longValue(),
-                        downloadFinishedEvent.getDownloadType().toString().replace("drm/license/", ""));
+            try {
+                if (downloadFinishedEvent.getDownloadType().toString().contains("drm/license")) {
+                    drmInformation = new DRMInformation(Double.valueOf(downloadFinishedEvent.getDownloadTime() * 1000).longValue(),
+                            downloadFinishedEvent.getDownloadType().toString().replace("drm/license/", ""));
+                }
+            } catch (Exception e) {
+                Log.d(TAG, "On Download Finished", e);
             }
         }
     };
@@ -483,29 +571,41 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnErrorListener onErrorListener = new OnErrorListener() {
         @Override
         public void onError(ErrorEvent errorEvent) {
-            Log.d(TAG, "onPlayerError");
-            long videoTime = getPosition();
-            ErrorCode errorCode = exceptionMapper.map(errorEvent);
+            try {
+                Log.d(TAG, "onPlayerError");
+                long videoTime = getPosition();
+                ErrorCode errorCode = exceptionMapper.map(errorEvent);
 
-            stateMachine.setErrorCode(errorCode);
-            if (!stateMachine.isStartupFinished() && isVideoAttemptedPlay) {
-                stateMachine.setVideoStartFailedReason(VideoStartFailedReason.PLAYER_ERROR);
+                stateMachine.setErrorCode(errorCode);
+                if (!stateMachine.isStartupFinished() && isVideoAttemptedPlay) {
+                    stateMachine.setVideoStartFailedReason(VideoStartFailedReason.PLAYER_ERROR);
+                }
+                stateMachine.transitionState(PlayerState.ERROR, videoTime);
+            } catch (Exception e) {
+                Log.d(TAG, "On Error", e);
             }
-            stateMachine.transitionState(PlayerState.ERROR, videoTime);
         }
     };
 
     private OnAdBreakStartedListener onAdBreakStartedListener = new OnAdBreakStartedListener() {
         @Override
         public void onAdBreakStarted(AdBreakStartedEvent adBreakStartedEvent) {
-            stateMachine.startAd(getPosition());
+            try {
+                stateMachine.startAd(getPosition());
+            } catch (Exception e) {
+                Log.d(TAG, "On Ad Break Started", e);
+            }
         }
     };
 
     private OnAdBreakFinishedListener onAdBreakFinishedListener = new OnAdBreakFinishedListener() {
         @Override
         public void onAdBreakFinished(AdBreakFinishedEvent adBreakFinishedEvent) {
-            stateMachine.transitionState(PlayerState.ADFINISHED, getPosition());
+            try {
+             stateMachine.transitionState(PlayerState.ADFINISHED, getPosition());
+            } catch (Exception e){
+                Log.d(TAG, "On Ad Break Finished", e);
+            }
         }
     };
 }

--- a/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
+++ b/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
@@ -317,7 +317,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnDestroyListener onDestroyedListener = new OnDestroyListener() {
         @Override
         public void onDestroy(DestroyEvent destroyEvent) {
-            try{
+            try {
                 Log.d(TAG, "On Destroy");
                 if (!stateMachine.isStartupFinished() && isVideoAttemptedPlay) {
                       stateMachine.setVideoStartFailedReason(VideoStartFailedReason.PAGE_CLOSED);
@@ -433,7 +433,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnAudioChangedListener onAudioChangedListener = new OnAudioChangedListener() {
         @Override
         public void onAudioChanged(AudioChangedEvent audioChangedEvent) {
-            try{
+            try {
                 Log.d(TAG, "On AudioChanged: " + bitmovinPlayer.getAudio().getId());
                 if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.isStartupFinished()) {
                     PlayerState originalState = stateMachine.getCurrentState();
@@ -449,7 +449,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
     private OnSubtitleChangedListener onSubtitleChangedListener = new OnSubtitleChangedListener() {
         @Override
         public void onSubtitleChanged(SubtitleChangedEvent event) {
-            try{
+            try {
                 Log.d(TAG, "On SubtitleChanged: " + bitmovinPlayer.getSubtitle().getId());
                 if ((stateMachine.getCurrentState() == PlayerState.PLAYING || stateMachine.getCurrentState() == PlayerState.PAUSE) && stateMachine.isStartupFinished()) {
                     PlayerState originalState = stateMachine.getCurrentState();
@@ -577,7 +577,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
         public void onAdBreakFinished(AdBreakFinishedEvent adBreakFinishedEvent) {
             try {
              stateMachine.transitionState(PlayerState.ADFINISHED, getPosition());
-            } catch (Exception e){
+            } catch (Exception e) {
                 Log.d(TAG, "On Ad Break Finished", e);
             }
         }

--- a/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
+++ b/collector-bitmovin-player/src/main/java/com/bitmovin/analytics/bitmovin/player/BitmovinSdkAdapter.java
@@ -309,7 +309,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                 Log.d(TAG, "On Source Unloaded");
                 stateMachine.resetStateMachine();
             } catch (Exception e) {
-                Log.d(TAG, "On Source Unloaded", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -324,7 +324,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                       stateMachine.transitionState(PlayerState.EXITBEFOREVIDEOSTART, getPosition());
                 }
             } catch (Exception e) {
-                Log.d(TAG, "On Destroyed", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -339,7 +339,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                 stateMachine.transitionState(PlayerState.PAUSE, position);
                 stateMachine.disableHeartbeat();
             } catch (Exception e) {
-                Log.d(TAG, "On Playback Finished", e);
+                Log.d(TAG, e.getMessage(), e);
             }
 
         }
@@ -360,7 +360,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                 Log.d(TAG, "On Pause Listener");
                 stateMachine.pause(getPosition());
             } catch (Exception e) {
-                Log.d(TAG, "On Pause", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -374,7 +374,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                     startup();
                 }
             } catch (Exception e) {
-                Log.d(TAG, "On Play", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -386,7 +386,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                 Log.d(TAG, "On Playing Listener " + stateMachine.getCurrentState().toString());
                 stateMachine.transitionState(PlayerState.PLAYING, getPosition());
             } catch (Exception e) {
-                Log.d(TAG, "On Playing", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -407,7 +407,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                     stateMachine.transitionState(PlayerState.SEEKING, getPosition());
                 }
             } catch (Exception e) {
-                Log.d(TAG, "On Seek", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -425,7 +425,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                     }
                 }
             } catch (Exception e) {
-                Log.d(TAG, "On Stall Ended", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -441,7 +441,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                     stateMachine.transitionState(originalState, getPosition());
                 }
             } catch (Exception e) {
-                Log.d(TAG, "On Audio Changed", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -457,7 +457,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                     stateMachine.transitionState(originalState, getPosition());
                 }
             } catch (Exception e) {
-                Log.d(TAG, "On Subtitle Changed", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -471,7 +471,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                     stateMachine.transitionState(PlayerState.BUFFERING, getPosition());
                 }
             } catch (Exception e) {
-                Log.d(TAG, "On Stall Started", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -489,7 +489,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                     stateMachine.transitionState(originalState, getPosition());
                 }
             } catch (Exception e) {
-                Log.d(TAG, "On Video Playback Quality Changed", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -500,7 +500,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
             try {
                 totalDroppedVideoFrames += droppedVideoFramesEvent.getDroppedFrames();
             } catch (Exception e) {
-                Log.d(TAG, "On Dropped Video Frames", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -523,7 +523,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                     stateMachine.transitionState(originalState, getPosition());
                 }
             } catch (Exception e) {
-                Log.d(TAG, "On Audio Quality Changed", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -537,7 +537,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                             downloadFinishedEvent.getDownloadType().toString().replace("drm/license/", ""));
                 }
             } catch (Exception e) {
-                Log.d(TAG, "On Download Finished", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -556,7 +556,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
                 }
                 stateMachine.transitionState(PlayerState.ERROR, videoTime);
             } catch (Exception e) {
-                Log.d(TAG, "On Error", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -567,7 +567,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
             try {
                 stateMachine.startAd(getPosition());
             } catch (Exception e) {
-                Log.d(TAG, "On Ad Break Started", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };
@@ -578,7 +578,7 @@ public class BitmovinSdkAdapter implements PlayerAdapter {
             try {
              stateMachine.transitionState(PlayerState.ADFINISHED, getPosition());
             } catch (Exception e) {
-                Log.d(TAG, "On Ad Break Finished", e);
+                Log.d(TAG, e.getMessage(), e);
             }
         }
     };

--- a/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
+++ b/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
@@ -250,7 +250,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
                     Log.d(TAG, "Unknown Player PlayerState encountered");
             }
         } catch (Exception e) {
-            Log.d(TAG, "On Player State Change", e);
+            Log.d(TAG, e.getMessage(), e);
         }
     }
 
@@ -262,7 +262,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
                 startup(getPosition());
             }
         } catch(Exception e) {
-            Log.d(TAG, "On Is Playing Changed", e);
+            Log.d(TAG, e.getMessage(), e);
         }
     }
 
@@ -291,7 +291,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
             this.stateMachine.setErrorCode(errorCode);
             this.stateMachine.transitionState(PlayerState.ERROR, videoTime);
         } catch (Exception e) {
-            Log.d(TAG, "On Player Error", e);
+            Log.d(TAG, e.getMessage(), e);
         }
     }
 
@@ -404,7 +404,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
             long videoTime = getPosition();
             this.stateMachine.transitionState(PlayerState.SEEKING, videoTime);
         } catch (Exception e) {
-            Log.d(TAG, "On Seek Started", e);
+            Log.d(TAG, e.getMessage(), e);
         }
 
     }
@@ -465,7 +465,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
                addSpeedMeasurement(loadEventInfo);
            }
        } catch (Exception e) {
-           Log.d(TAG, "On Load Completed", e);
+           Log.d(TAG, e.getMessage(), e);
        }
     }
 
@@ -578,7 +578,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
                 }
             }
         } catch (Exception e) {
-            Log.d(TAG, "On Decoder Input Format Changed", e);
+            Log.d(TAG, e.getMessage(), e);
         }
     }
 
@@ -612,7 +612,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
         try {
             this.totalDroppedVideoFrames += droppedFrames;
         } catch (Exception e) {
-            Log.d(TAG, "On Dropped Video Frames", e);
+            Log.d(TAG, e.getMessage(), e);
         }
     }
 
@@ -632,7 +632,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
             drmLoadStartTime = eventTime.realtimeMs;
             Log.d(TAG, String.format("DRM Session aquired %d", eventTime.realtimeMs));
         } catch (Exception e) {
-            Log.d(TAG, "On DRM Session Acquired", e);
+            Log.d(TAG, e.getMessage(), e);
         }
     }
 
@@ -642,7 +642,7 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
             drmInformation = new DRMInformation(eventTime.realtimeMs - drmLoadStartTime, drmType);
             Log.d(TAG, String.format("DRM Keys loaded %d", eventTime.realtimeMs));
         } catch (Exception e) {
-            Log.d(TAG, "On Drm Keys Loaded", e);
+            Log.d(TAG, e.getMessage(), e);
         }
     }
 

--- a/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
+++ b/collector-exoplayer/src/main/java/com/bitmovin/analytics/exoplayer/ExoPlayerAdapter.java
@@ -124,43 +124,34 @@ public class ExoPlayerAdapter implements PlayerAdapter, Player.EventListener, An
 
     @Override
     public EventData createEventData() {
-        try {
-            EventData data = factory.build(stateMachine.getImpressionId());
+        EventData data = factory.build(stateMachine.getImpressionId());
 
-            data.setAnalyticsVersion(BuildConfig.VERSION_NAME);
-            data.setPlayer(PlayerType.EXOPLAYER.toString());
-            decorateDataWithPlaybackInformation(data);
-            data.setDownloadSpeedInfo(meter.getInfo());
+        data.setAnalyticsVersion(BuildConfig.VERSION_NAME);
+        data.setPlayer(PlayerType.EXOPLAYER.toString());
+        decorateDataWithPlaybackInformation(data);
+        data.setDownloadSpeedInfo(meter.getInfo());
 
-            // DRM Information
-            if (drmInformation != null) {
-                data.setDrmType(drmInformation.getType());
-            }
-
-            return data;
-        } catch (Exception e) {
-            Log.d(TAG, "On Create Event Data", e);
+        // DRM Information
+        if (drmInformation != null) {
+            data.setDrmType(drmInformation.getType());
         }
-        return null;
+
+        return data;
     }
 
     @Override
     public void release() {
-        try {
-            playerIsReady = false;
-            manifestUrl = null;
-            if (this.exoplayer != null) {
-                this.exoplayer.removeListener(this);
-            }
-            if (this.exoplayer instanceof SimpleExoPlayer) {
-                SimpleExoPlayer simpleExoPlayer = (SimpleExoPlayer) this.exoplayer;
-                simpleExoPlayer.removeAnalyticsListener(this);
-            }
-            meter.reset();
-            stateMachine.resetStateMachine();
-        } catch (Exception e) {
-            Log.d(TAG, "Release", e);
+        playerIsReady = false;
+        manifestUrl = null;
+        if (this.exoplayer != null) {
+            this.exoplayer.removeListener(this);
         }
+        if (this.exoplayer instanceof SimpleExoPlayer) {
+            SimpleExoPlayer simpleExoPlayer = (SimpleExoPlayer) this.exoplayer;
+            simpleExoPlayer.removeAnalyticsListener(this);
+        }
+        meter.reset();
+        stateMachine.resetStateMachine();
     }
 
     @Override


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-1675
- Description: Added try-catch blocks around exoplayer and bitmovin listener methods. Didn't put them around all possible methods because in some cases methods have non nullable return type and in case of exceptions returning some default value like `false` or `0` would cause having wrong data in collector.


### Checklist

- [X] Updated CHANGELOG.md
