### PR TITLE
Feature/deploy script improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,9 @@ allprojects {
 
 ext {
     developLocal =  System.getProperty("developLocal", "true").toBoolean()
+    versionNameSuffix = developLocal ? '-local' : ''
     packageGroupId = 'com.bitmovin.analytics'
-    version = '1.20.0'
+    version = '1.20.0' + versionNameSuffix
     versionCode = 120000
 
     compileSdkVersion = 28

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ allprojects {
 }
 
 ext {
-    developLocal = project.hasProperty('developLocal') ? project.getProperty('developLocal') : true
+    developLocal =  System.getProperty("developLocal", "true").toBoolean()
     packageGroupId = 'com.bitmovin.analytics'
     version = '1.20.0'
     versionCode = 120000

--- a/publish.sh
+++ b/publish.sh
@@ -50,7 +50,7 @@ if [ -z "$ANALYTICS_API_RELEASE_TOKEN" ]; then
     setEnvVariable "ANALYTICS_API_RELEASE_TOKEN" $ANALYTICS_API_RELEASE_TOKEN
 fi
 
-echo "Make sure to bump the libraryVersion and versionCode in the <root>/build.gradle file, README and CHANGELOG first and merge that PR into develop."
+echo "Make sure to bump the libraryVersion and versionCode in the <root>/build.gradle file, README and CHANGELOG first and merge that PR into develop. After releasing, change the \"developLocal\" to false manually and start both the examples and make sure that the outgoing payload doesn't include \"-local\" in the version string."
 echo "Version (without leading \"v\")":
 read VERSION
 git checkout develop

--- a/publish.sh
+++ b/publish.sh
@@ -50,7 +50,7 @@ if [ -z "$ANALYTICS_API_RELEASE_TOKEN" ]; then
     setEnvVariable "ANALYTICS_API_RELEASE_TOKEN" $ANALYTICS_API_RELEASE_TOKEN
 fi
 
-echo "Make sure to bump the libraryVersion and versionCode in the <root>/build.gradle file, README and CHANGELOG first and merge that PR into develop. After releasing, change the \"developLocal\" to false manually and start both the examples and make sure that the outgoing payload doesn't include \"-local\" in the version string."
+echo "Make sure to bump the libraryVersion and versionCode in the <root>/build.gradle file, README and CHANGELOG first and merge that PR into develop.\n\nAfter releasing, change the \"developLocal\" to false manually and start both the examples and make sure that the outgoing payload doesn't include \"-local\" in the version string (and pull the right version from artifactory).\n"
 echo "Version (without leading \"v\")":
 read VERSION
 git checkout develop

--- a/publish.sh
+++ b/publish.sh
@@ -73,24 +73,24 @@ curl \
 echo "Created release in public repo."
 
 echo "Creating and publishing :collector project..."
-./gradlew -PdevelopLocal=false :collector:clean
-./gradlew -PdevelopLocal=false :collector:build
-./gradlew -PdevelopLocal=false :collector:assembleRelease
-./gradlew -PdevelopLocal=false :collector:artifactoryPublish
+./gradlew -DdevelopLocal=false :collector:clean
+./gradlew -DdevelopLocal=false :collector:build
+./gradlew -DdevelopLocal=false :collector:assembleRelease
+./gradlew -DdevelopLocal=false :collector:artifactoryPublish
 echo "Created and published :collector project."
 
 echo "Creating and publishing :collector-bitmovin-player project..."
-./gradlew -PdevelopLocal=false :collector-bitmovin-player:clean
-./gradlew -PdevelopLocal=false :collector-bitmovin-player:build
-./gradlew -PdevelopLocal=false :collector-bitmovin-player:assembleRelease
-./gradlew -PdevelopLocal=false :collector-bitmovin-player:artifactoryPublish
+./gradlew -DdevelopLocal=false :collector-bitmovin-player:clean
+./gradlew -DdevelopLocal=false :collector-bitmovin-player:build
+./gradlew -DdevelopLocal=false :collector-bitmovin-player:assembleRelease
+./gradlew -DdevelopLocal=false :collector-bitmovin-player:artifactoryPublish
 echo "Created and published :collector-bitmovin-player project."
 
 echo "Creating and publishing :collector-exoplayer project..."
-./gradlew -PdevelopLocal=false :collector-exoplayer:clean
-./gradlew -PdevelopLocal=false :collector-exoplayer:build
-./gradlew -PdevelopLocal=false :collector-exoplayer:assembleRelease
-./gradlew -PdevelopLocal=false :collector-exoplayer:artifactoryPublish
+./gradlew -DdevelopLocal=false :collector-exoplayer:clean
+./gradlew -DdevelopLocal=false :collector-exoplayer:build
+./gradlew -DdevelopLocal=false :collector-exoplayer:assembleRelease
+./gradlew -DdevelopLocal=false :collector-exoplayer:artifactoryPublish
 echo "Created and published :collector-exoplayer project."
 
 file="./bitmovin.properties"


### PR DESCRIPTION
### Work
- Fixes: https://bitmovin.atlassian.net/browse/AN-1880
- Description: Deploy script didn't override `developLocal` properly. Changed setting the `developLocal` in the deploy script to a system property.

I'm pretty confident this works now, but as this can only be really tested with a real release, let's take a close look at the next time we release something.
Also, when releasing, we should try to debug both exoplayer and bitmovin player at least once, manually setting `developLocal` to `false` and checking if the outgoing `version` includes the `-local` or not (if it doesn't, it should correctly have pulled the version from artifactory).

### Checklist

- [ ] Updated CHANGELOG.md
